### PR TITLE
Implementing MEGAHIT Into YEAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for FastQC (#5)
+- Support for MEGAHIT (#13)
 
 
 ## [0.1] 2021-12-01

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,7 +13,8 @@ import pandas as pd
 
 rule all:
     input:
-        expand("analysis/quast/{sample}/report.html", sample=config["sample"]),
+        if config["algorithm"] == "spades":
+            expand("analysis/quast/{sample}/report.html", sample=config["sample"]),
         expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
 
 
@@ -104,9 +105,27 @@ rule spades:
     shell: "spades.py -1 {input.read1} -2 {input.read2} -o analysis/spades/{wildcards.sample}"
 
 
-rule quast:
+rule megahit:
+    output:
+        contigs="analysis/megahit/{sample}/final.contigs.fa"
+    input:
+        read1="seq/downsample/{sample}.R1.fq.gz",
+        read2="seq/downsample/{sample}.R2.fq.gz",
+    threads: 8
+    shell: "megahit -1 {input.read1} -2 {input.read2} -o analysis/megahit/{wildcards.sample}"
+
+
+rule spades_quast:
     output:
         report="analysis/quast/{sample}/report.html",
     input:
         scaffold="analysis/spades/{sample}/scaffolds.fasta",
+    shell: "quast.py {input.scaffold} -o analysis/quast/{wildcards.sample}"
+
+
+rule megahit_quast:
+    output:
+        report="analysis/quast/{sample}/report.html",
+    input:
+        scaffold="analysis/megahit/{sample}/scaffolds.fasta",
     shell: "quast.py {input.scaffold} -o analysis/quast/{wildcards.sample}"

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,7 +13,7 @@ import pandas as pd
 
 rule all:
     input:
-        expand("analysis/quast/{assemblers}/{sample}_report.html", assemblers=config["assemblers"], sample=config["sample"]),
+        expand("analysis/quast/{assembler}/{sample}_report.html", assembler=config["assemblers"], sample=config["sample"]),
         expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
 
 
@@ -125,11 +125,11 @@ rule megahit:
 
 rule quast:
     output:
-        report="analysis/quast/{assemblers}/{sample}_report.html"
+        report="analysis/quast/{assembler}/{sample}_report.html"
     input:
-        contigs="analysis/{assemblers}/{sample}_contigs.fasta"
+        contigs="analysis/{assembler}/{sample}_contigs.fasta"
     shell:
         """
-        quast.py {input.contigs} -o analysis/quast/{wildcards.assemblers}
+        quast.py {input.contigs} -o analysis/quast/{wildcards.assembler}
         ln -s report.html {output.report}
         """

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,8 +13,8 @@ import pandas as pd
 
 rule all:
     input:
-        expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"]),
         expand("analysis/quast/{assembly}/{sample}_report.html", assembly=config["assembly"], sample=config["sample"])
+        expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"]),
 
 
 rule copyinput:

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,7 +13,7 @@ import pandas as pd
 
 rule all:
     input:
-        expand("analysis/quast/{assembly}/{sample}_report.html", assembly=config["assembly"], sample=config["sample"]),
+        expand("analysis/quast/{assemblers}/{sample}_report.html", assemblers=config["assemblers"], sample=config["sample"]),
         expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
 
 
@@ -36,7 +36,7 @@ rule fastqc:
     input:
         read1="seq/input/{sample}_R1.fq.gz",
         read2="seq/input/{sample}_R2.fq.gz"
-    threads: 2
+    threads: 128
     shell:
         """
         fastqc {input.read1} {input.read2} --threads {threads} -o seq/fastqc/
@@ -99,7 +99,7 @@ rule spades:
     input:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz"
-    threads: 8
+    threads: 128
     shell:
         """
         spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades
@@ -113,7 +113,7 @@ rule megahit:
     input:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz",
-    threads: 8
+    threads: 128
     shell:
         """
         megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit-temp
@@ -125,11 +125,11 @@ rule megahit:
 
 rule quast:
     output:
-        report="analysis/quast/{assembly}/{sample}_report.html"
+        report="analysis/quast/{assemblers}/{sample}_report.html"
     input:
-        contigs="analysis/{assembly}/{sample}_contigs.fasta"
+        contigs="analysis/{assemblers}/{sample}_contigs.fasta"
     shell:
         """
-        quast.py {input.contigs} -o analysis/quast/{wildcards.assembly}
+        quast.py {input.contigs} -o analysis/quast/{wildcards.assemblers}
         ln -s report.html {output.report}
         """

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,8 +13,8 @@ import pandas as pd
 
 rule all:
     input:
-        expand("analysis/quast/{assembly}/{sample}_report.html", assembly=config["assembly"], sample=config["sample"])
-        expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"]),
+        expand("analysis/quast/{assembly}/{sample}_report.html", assembly=config["assembly"], sample=config["sample"]),
+        expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
 
 
 rule copyinput:

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,9 +13,8 @@ import pandas as pd
 
 rule all:
     input:
-        if config["algorithm"] == "spades":
-            expand("analysis/quast/{sample}/report.html", sample=config["sample"]),
-        expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
+        expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"]),
+        expand("analysis/quast/{assembly}/{sample}_report.html", assembly=config["assembly"], sample=config["sample"])
 
 
 rule copyinput:
@@ -47,7 +46,7 @@ rule fastqc:
 rule fastp:
     output:
         out1="seq/fastp/{sample}.R1.fq.gz",
-        out2="seq/fastp/{sample}.R2.fq.gz",
+        out2="seq/fastp/{sample}.R2.fq.gz"
     input:
         read1="seq/input/{sample}_R1.fq.gz",
         read2="seq/input/{sample}_R2.fq.gz"
@@ -64,7 +63,7 @@ rule mash:
         sketch="seq/mash/{sample}.R1.fq.gz.msh",
         mash_report="seq/mash/{sample}.report.tsv"
     input:
-        read1=rules.fastp.output.out1
+        read1="seq/fastp/{sample}.R1.fq.gz"
     shell:
         """
         mash sketch {input.read1} -o {output.sketch}
@@ -75,7 +74,7 @@ rule mash:
 rule downsample:
     output:
         sub1="seq/downsample/{sample}.R1.fq.gz",
-        sub2="seq/downsample/{sample}.R2.fq.gz",
+        sub2="seq/downsample/{sample}.R2.fq.gz"
     input:
         read1="seq/fastp/{sample}.R1.fq.gz",
         read2="seq/fastp/{sample}.R2.fq.gz",
@@ -96,36 +95,35 @@ rule downsample:
 
 rule spades:
     output:
-        contigs="analysis/spades/{sample}/contigs.fasta",
-        scaffolds="analysis/spades/{sample}/scaffolds.fasta",
+        contigs="analysis/spades/{sample}_contigs.fasta"
     input:
         read1="seq/downsample/{sample}.R1.fq.gz",
-        read2="seq/downsample/{sample}.R2.fq.gz",
+        read2="seq/downsample/{sample}.R2.fq.gz"
     threads: 8
-    shell: "spades.py -1 {input.read1} -2 {input.read2} -o analysis/spades/{wildcards.sample}"
+    run:
+        shell("spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades")
+        shell("mv analysis/spades/scaffolds.fasta {output.contigs}")
 
 
 rule megahit:
     output:
-        contigs="analysis/megahit/{sample}/final.contigs.fa"
+        contigs="analysis/megahit/{sample}_contigs.fasta"
     input:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz",
     threads: 8
-    shell: "megahit -1 {input.read1} -2 {input.read2} -o analysis/megahit/{wildcards.sample}"
+    run:
+        shell("rm -r analysis")
+        shell("mkdir analysis")
+        shell("megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit/")
+        shell("mv analysis/megahit/final.contigs.fa {output.contigs}")
 
 
-rule spades_quast:
+rule quast:
     output:
-        report="analysis/quast/{sample}/report.html",
+        report="analysis/quast/{assembly}/{sample}_report.html"
     input:
-        scaffold="analysis/spades/{sample}/scaffolds.fasta",
-    shell: "quast.py {input.scaffold} -o analysis/quast/{wildcards.sample}"
-
-
-rule megahit_quast:
-    output:
-        report="analysis/quast/{sample}/report.html",
-    input:
-        scaffold="analysis/megahit/{sample}/scaffolds.fasta",
-    shell: "quast.py {input.scaffold} -o analysis/quast/{wildcards.sample}"
+        contigs="analysis/{assembly}/{sample}_contigs.fasta"
+    run:
+        shell("quast.py {input.contigs} -o analysis/quast/{wildcards.assembly}")
+        shell("mv analysis/quast/{wildcards.assembly}/report.html {output.report}")

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -100,9 +100,11 @@ rule spades:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz"
     threads: 8
-    run:
-        shell("spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades")
-        shell("mv analysis/spades/scaffolds.fasta {output.contigs}")
+    shell:
+        """
+        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades
+        ln -s scaffolds.fasta {output.contigs}
+        """
 
 
 rule megahit:
@@ -112,11 +114,13 @@ rule megahit:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz",
     threads: 8
-    run:
-        shell("rm -r analysis")
-        shell("mkdir analysis")
-        shell("megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit/")
-        shell("mv analysis/megahit/final.contigs.fa {output.contigs}")
+    shell:
+        """
+        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit-temp
+        mv analysis/megahit-temp/* analysis/megahit
+        rm -r analysis/megahit-temp
+        ln -s final.contigs.fa {output.contigs}
+        """
 
 
 rule quast:
@@ -124,6 +128,8 @@ rule quast:
         report="analysis/quast/{assembly}/{sample}_report.html"
     input:
         contigs="analysis/{assembly}/{sample}_contigs.fasta"
-    run:
-        shell("quast.py {input.contigs} -o analysis/quast/{wildcards.assembly}")
-        shell("mv analysis/quast/{wildcards.assembly}/report.html {output.report}")
+    shell:
+        """
+        quast.py {input.contigs} -o analysis/quast/{wildcards.assembly}
+        ln -s report.html {output.report}
+        """

--- a/yeat/__init__.py
+++ b/yeat/__init__.py
@@ -1,4 +1,3 @@
-from . import cli
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -101,7 +101,7 @@ def check_assemblies(assembly):
                 f"Found duplicate assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
             )
             warnings.warn(message)
-            continue
+            sys.exit()
         algorithms.append(algorithm)
     return algorithms
 

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -11,8 +11,6 @@ import argparse
 from pathlib import Path
 from pkg_resources import resource_filename
 from snakemake import snakemake
-import sys
-import warnings
 import yeat
 
 
@@ -94,14 +92,12 @@ def check_assemblies(assembly):
             message = (
                 f"Found unsupported assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
             )
-            warnings.warn(message)
-            sys.exit()
+            raise ValueError(message)
         if algorithm in algorithms:
             message = (
                 f"Found duplicate assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
             )
-            warnings.warn(message)
-            sys.exit()
+            raise ValueError(message)
         algorithms.append(algorithm)
     return algorithms
 

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -91,8 +91,8 @@ def get_parser():
         action="store_true",
         help="construct workflow DAG and print a summary but do not execute",
     )
-    group = parser.add_argument_group("required arguments")
-    group.add_argument(
+    required = parser.add_argument_group("required arguments")
+    required.add_argument(
         "--assembly",
         required=True,
         type=str,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -14,13 +14,14 @@ from snakemake import snakemake
 import yeat
 
 
-def run(read1, read2, outdir=".", cores=1, sample="sample", dryrun="dry"):
+def run(read1, read2, algorithm, outdir=".", cores=1, sample="sample", dryrun="dry"):
     snakefile = resource_filename("yeat", "Snakefile")
     r1 = Path(read1).resolve()
     r2 = Path(read2).resolve()
     config = dict(
         read1=r1,
         read2=r2,
+        algorithm=algorithm,
         outdir=outdir,
         cores=cores,
         sample=sample,
@@ -70,6 +71,9 @@ def get_parser():
         action="store_true",
         help="construct workflow DAG and print a summary but do not execute",
     )
+    parser.add_argument(
+        "algorithm", type=str, help="assembly algorithm; For example, `spades` or `megahit`"
+    )
     parser.add_argument("reads", type=str, nargs=2, help="paired-end reads in FASTQ format")
     return parser
 
@@ -80,6 +84,7 @@ def main(args=None):
     assert len(args.reads) == 2
     run(
         *args.reads,
+        algorithm=args.algorithm,
         outdir=args.outdir,
         cores=args.threads,
         sample=args.sample,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -17,30 +17,30 @@ import yeat
 ASSEMBLY_ALGORITHMS = ["spades", "megahit"]
 
 
-def check_assembly(assembly):
+def check_assemblers(assemblers):
     algorithms = []
-    for algorithm in assembly:
+    for algorithm in assemblers:
         if algorithm not in ASSEMBLY_ALGORITHMS:
             message = (
-                f"Found unsupported assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
+                f"Found unsupported assembly algorithm with `--assemblers` flag: [[{algorithm}]]!"
             )
             raise ValueError(message)
         if algorithm in algorithms:
             message = (
-                f"Found duplicate assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
+                f"Found duplicate assembly algorithm with `--assemblers` flag: [[{algorithm}]]!"
             )
             raise ValueError(message)
         algorithms.append(algorithm)
 
 
-def run(read1, read2, assembly, outdir=".", cores=1, sample="sample", dryrun="dry"):
+def run(read1, read2, assemblers, outdir=".", cores=1, sample="sample", dryrun="dry"):
     snakefile = resource_filename("yeat", "Snakefile")
     r1 = Path(read1).resolve()
     r2 = Path(read2).resolve()
     config = dict(
         read1=r1,
         read2=r2,
-        assembly=assembly,
+        assemblers=assemblers,
         outdir=outdir,
         cores=cores,
         sample=sample,
@@ -92,7 +92,7 @@ def get_parser():
     )
     required = parser.add_argument_group("required arguments")
     required.add_argument(
-        "--assembly",
+        "--assemblers",
         required=True,
         type=str,
         help="assembly algorithm(s); For example, `spades`, `megahit`, or `spades,megahit`",
@@ -105,11 +105,11 @@ def main(args=None):
     if args is None:
         args = get_parser().parse_args()
     assert len(args.reads) == 2
-    assembly = list(filter(None, args.assembly.strip().split(",")))
-    check_assembly(assembly)
+    assemblers = list(filter(None, args.assemblers.strip().split(",")))
+    check_assemblers(assemblers)
     run(
         *args.reads,
-        assembly=assembly,
+        assemblers=assemblers,
         outdir=args.outdir,
         cores=args.threads,
         sample=args.sample,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -17,6 +17,48 @@ import yeat
 ASSEMBLY_ALGORITHMS = ["spades", "megahit"]
 
 
+def check_assemblies(assembly):
+    algorithms = []
+    for algorithm in assembly:
+        if algorithm not in ASSEMBLY_ALGORITHMS:
+            message = (
+                f"Found unsupported assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
+            )
+            raise ValueError(message)
+        if algorithm in algorithms:
+            message = (
+                f"Found duplicate assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
+            )
+            raise ValueError(message)
+        algorithms.append(algorithm)
+    return algorithms
+
+
+def run(read1, read2, assembly, outdir=".", cores=1, sample="sample", dryrun="dry"):
+    snakefile = resource_filename("yeat", "Snakefile")
+    r1 = Path(read1).resolve()
+    r2 = Path(read2).resolve()
+    config = dict(
+        read1=r1,
+        read2=r2,
+        assembly=assembly,
+        outdir=outdir,
+        cores=cores,
+        sample=sample,
+        dryrun=dryrun,
+    )
+    success = snakemake(
+        snakefile,
+        config=config,
+        cores=cores,
+        dryrun=dryrun,
+        printshellcmds=True,
+        workdir=outdir,
+    )
+    if not success:
+        raise RuntimeError("Snakemake Failed")
+
+
 def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--version", action="version", version=f"YEAT v{yeat.__version__}")
@@ -58,48 +100,6 @@ def get_parser():
     )
     parser.add_argument("reads", type=str, nargs=2, help="paired-end reads in FASTQ format")
     return parser
-
-
-def run(read1, read2, assembly, outdir=".", cores=1, sample="sample", dryrun="dry"):
-    snakefile = resource_filename("yeat", "Snakefile")
-    r1 = Path(read1).resolve()
-    r2 = Path(read2).resolve()
-    config = dict(
-        read1=r1,
-        read2=r2,
-        assembly=assembly,
-        outdir=outdir,
-        cores=cores,
-        sample=sample,
-        dryrun=dryrun,
-    )
-    success = snakemake(
-        snakefile,
-        config=config,
-        cores=cores,
-        dryrun=dryrun,
-        printshellcmds=True,
-        workdir=outdir,
-    )
-    if not success:
-        raise RuntimeError("Snakemake Failed")
-
-
-def check_assemblies(assembly):
-    algorithms = []
-    for algorithm in assembly:
-        if algorithm not in ASSEMBLY_ALGORITHMS:
-            message = (
-                f"Found unsupported assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
-            )
-            raise ValueError(message)
-        if algorithm in algorithms:
-            message = (
-                f"Found duplicate assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
-            )
-            raise ValueError(message)
-        algorithms.append(algorithm)
-    return algorithms
 
 
 def main(args=None):

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from pkg_resources import resource_filename
 from snakemake import snakemake
 import sys
+import warnings
 import yeat
 
 
@@ -22,7 +23,7 @@ def get_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("-v", "--version", action="version", version=f"YEAT v{yeat.__version__}")
     parser.add_argument(
-        "-O",
+        "-o",
         "--outdir",
         type=str,
         metavar="DIR",
@@ -90,11 +91,17 @@ def check_assemblies(assembly):
     algorithms = []
     for algorithm in assembly:
         if algorithm not in ASSEMBLY_ALGORITHMS:
-            message = f"Found unsupported assembly algorithm in config file: [[{algorithm}]]!"
-            sys.exit(message)
+            message = (
+                f"Found unsupported assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
+            )
+            warnings.warn(message)
+            sys.exit()
         if algorithm in algorithms:
-            message = f"Found duplicate assembly algorithm in config file: [[{algorithm}]]!"
-            sys.exit(message)
+            message = (
+                f"Found duplicate assembly algorithm with `--assembly` flag: [[{algorithm}]]!"
+            )
+            warnings.warn(message)
+            continue
         algorithms.append(algorithm)
     return algorithms
 

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -17,7 +17,7 @@ import yeat
 ASSEMBLY_ALGORITHMS = ["spades", "megahit"]
 
 
-def check_assemblies(assembly):
+def check_assembly(assembly):
     algorithms = []
     for algorithm in assembly:
         if algorithm not in ASSEMBLY_ALGORITHMS:
@@ -31,7 +31,6 @@ def check_assemblies(assembly):
             )
             raise ValueError(message)
         algorithms.append(algorithm)
-    return algorithms
 
 
 def run(read1, read2, assembly, outdir=".", cores=1, sample="sample", dryrun="dry"):
@@ -107,7 +106,7 @@ def main(args=None):
         args = get_parser().parse_args()
     assert len(args.reads) == 2
     assembly = list(filter(None, args.assembly.strip().split(",")))
-    assembly = check_assemblies(assembly)
+    check_assembly(assembly)
     run(
         *args.reads,
         assembly=assembly,

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -8,7 +8,6 @@
 # -------------------------------------------------------------------------------------------------
 
 import pytest
-import warnings
 import yeat
 from yeat import cli
 from yeat.tests import data_file

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_basic_dry_run(tmp_path):
     arglist = [
         data_file("Animal_289_R1.fq.gz"),
         data_file("Animal_289_R2.fq.gz"),
-        "--assembly",
+        "--assemblers",
         "spades",
         "--outdir",
         wd,
@@ -41,19 +41,19 @@ def test_snakemake_fail_because_of_invalid_read_files():
     with pytest.raises(Exception, match=r"Snakemake Failed"):
         read1 = "read1"
         read2 = "read2"
-        assembly = "spades"
-        yeat.cli.run(read1, read2, assembly)
+        assemblers = "spades"
+        yeat.cli.run(read1, read2, assemblers)
 
 
 def test_unsupported_assembly_algorithm():
-    assembly = ["unsupported_assembly"]
-    error_message = r"Found unsupported assembly algorithm with `--assembly` flag: \[\[unsupported_assembly\]\]!"
+    assemblers = ["unsupported_assembly"]
+    error_message = r"Found unsupported assembly algorithm with `--assemblers` flag: \[\[unsupported_assembly\]\]!"
     with pytest.raises(ValueError, match=error_message):
-        yeat.cli.check_assembly(assembly)
+        yeat.cli.check_assemblers(assemblers)
 
 
 def test_duplicate_assembly_algorithms():
-    assembly = ["spades", "spades"]
-    error_message = r"Found duplicate assembly algorithm with `--assembly` flag: \[\[spades\]\]!"
+    assemblers = ["spades", "spades"]
+    error_message = r"Found duplicate assembly algorithm with `--assemblers` flag: \[\[spades\]\]!"
     with pytest.raises(ValueError, match=error_message):
-        yeat.cli.check_assembly(assembly)
+        yeat.cli.check_assemblers(assemblers)

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -8,6 +8,7 @@
 # -------------------------------------------------------------------------------------------------
 
 import pytest
+import warnings
 import yeat
 from yeat import cli
 from yeat.tests import data_file
@@ -19,6 +20,8 @@ def test_basic_dry_run(tmp_path):
     arglist = [
         data_file("Animal_289_R1.fq.gz"),
         data_file("Animal_289_R2.fq.gz"),
+        "--assembly",
+        "spades",
         "--outdir",
         wd,
         "--sample",
@@ -38,27 +41,19 @@ def test_snakemake_fail_because_of_invalid_read_files():
     with pytest.raises(Exception, match=r"Snakemake Failed"):
         read1 = "read1"
         read2 = "read2"
-        yeat.cli.run(read1, read2)
+        assembly = "spades"
+        yeat.cli.run(read1, read2, assembly)
 
 
 def test_unsupported_assembly_algorithm():
-    # data = [{"label": "assembly1", "algorithm": "unsupported_assembly"}]
-    # f = io.StringIO(json.dumps(data))
-    # error_message = (
-    #     r"Found unsupported assembly algorithm in config file: \[\[unsupported_assembly\]\]!"
-    # )
-    # with pytest.raises(config.AssemblyConfigError, match=error_message):
-    #     config.AssemblyConfiguration.parse_json(f)
-    pass
+    assembly = ["unsupported_assembly"]
+    error_message = r"Found unsupported assembly algorithm with `--assembly` flag: \[\[unsupported_assembly\]\]!"
+    with pytest.raises(ValueError, match=error_message):
+        yeat.cli.check_assemblies(assembly)
 
 
 def test_duplicate_assembly_algorithms():
-    # data = [
-    #     {"label": "assembly1", "algorithm": "spades"},
-    #     {"label": "assembly2", "algorithm": "spades"},
-    # ]
-    # f = io.StringIO(json.dumps(data))
-    # error_message = r"Found duplicate assembly algorithm in config file: \[\[spades\]\]!"
-    # with pytest.raises(config.AssemblyConfigError, match=error_message):
-    #     config.AssemblyConfiguration.parse_json(f)
-    pass
+    assembly = ["spades", "spades"]
+    error_message = r"Found duplicate assembly algorithm with `--assembly` flag: \[\[spades\]\]!"
+    with pytest.raises(ValueError, match=error_message):
+        yeat.cli.check_assemblies(assembly)

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -39,3 +39,26 @@ def test_snakemake_fail_because_of_invalid_read_files():
         read1 = "read1"
         read2 = "read2"
         yeat.cli.run(read1, read2)
+
+
+def test_unsupported_assembly_algorithm():
+    # data = [{"label": "assembly1", "algorithm": "unsupported_assembly"}]
+    # f = io.StringIO(json.dumps(data))
+    # error_message = (
+    #     r"Found unsupported assembly algorithm in config file: \[\[unsupported_assembly\]\]!"
+    # )
+    # with pytest.raises(config.AssemblyConfigError, match=error_message):
+    #     config.AssemblyConfiguration.parse_json(f)
+    pass
+
+
+def test_duplicate_assembly_algorithms():
+    # data = [
+    #     {"label": "assembly1", "algorithm": "spades"},
+    #     {"label": "assembly2", "algorithm": "spades"},
+    # ]
+    # f = io.StringIO(json.dumps(data))
+    # error_message = r"Found duplicate assembly algorithm in config file: \[\[spades\]\]!"
+    # with pytest.raises(config.AssemblyConfigError, match=error_message):
+    #     config.AssemblyConfiguration.parse_json(f)
+    pass

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -49,11 +49,11 @@ def test_unsupported_assembly_algorithm():
     assembly = ["unsupported_assembly"]
     error_message = r"Found unsupported assembly algorithm with `--assembly` flag: \[\[unsupported_assembly\]\]!"
     with pytest.raises(ValueError, match=error_message):
-        yeat.cli.check_assemblies(assembly)
+        yeat.cli.check_assembly(assembly)
 
 
 def test_duplicate_assembly_algorithms():
     assembly = ["spades", "spades"]
     error_message = r"Found duplicate assembly algorithm with `--assembly` flag: \[\[spades\]\]!"
     with pytest.raises(ValueError, match=error_message):
-        yeat.cli.check_assemblies(assembly)
+        yeat.cli.check_assembly(assembly)


### PR DESCRIPTION
The purpose of this PR is to close #10 .

In order to run YEAT, users will be required to provide the type of assembler that the user would like to run.

For example,
> yeat --assembly spades [read1] [read2]

In addition to the support for MEGAHIT, if the user would like to run multiple assemblers with the same reads, users can put a comma (",") after each assembler name.

For example,
> yeat --assembly spades,megahit [read1] [read2]

As of right now, YEAT can only assembler read with `spades` and `megahit`. More assemblers will be added in the future.