### PR TITLE
Adding multi-assembly config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for FastQC (#5)
 - Support for MEGAHIT (#13)
 - Support for Unicycler (#14)
+- Support for assembly configuration file (#16)
 
 
 ## [0.1] 2021-12-01

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -102,7 +102,7 @@ rule spades:
     threads: 128
     shell:
         """
-        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades
+        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades {config[extraargs][spades]}
         ln -s scaffolds.fasta {output.contigs}
         """
 
@@ -116,7 +116,7 @@ rule megahit:
     threads: 128
     shell:
         """
-        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit-temp
+        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit-temp {config[extraargs][megahit]}
         mv analysis/megahit-temp/* analysis/megahit
         rm -r analysis/megahit-temp
         ln -s final.contigs.fa {output.contigs}
@@ -131,7 +131,7 @@ rule unicycler:
         read2="seq/downsample/{sample}.R2.fq.gz"
     shell:
         """
-        unicycler -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/unicycler
+        unicycler -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/unicycler {config[extraargs][unicycler]}
         ln -s assembly.fasta {output.contigs}
         """
 

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,7 +13,7 @@ import pandas as pd
 
 rule all:
     input:
-        expand("analysis/quast/{algorithm}/{sample}_report.html", algorithm=config["algorithms"], sample=config["sample"]),
+        expand("analysis/quast/{assembler}/{sample}_report.html", assembler=config["assemblers"], sample=config["sample"]),
         expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
 
 
@@ -138,11 +138,11 @@ rule unicycler:
 
 rule quast:
     output:
-        report="analysis/quast/{algorithm}/{sample}_report.html"
+        report="analysis/quast/{assembler}/{sample}_report.html"
     input:
-        contigs="analysis/{algorithm}/{sample}_contigs.fasta"
+        contigs="analysis/{assembler}/{sample}_contigs.fasta"
     shell:
         """
-        quast.py {input.contigs} -o analysis/quast/{wildcards.algorithm}
+        quast.py {input.contigs} -o analysis/quast/{wildcards.assembler}
         ln -s report.html {output.report}
         """

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -13,7 +13,7 @@ import pandas as pd
 
 rule all:
     input:
-        expand("analysis/quast/{assembler}/{sample}_report.html", assembler=config["assemblers"], sample=config["sample"]),
+        expand("analysis/quast/{algorithm}/{sample}_report.html", algorithm=config["algorithms"], sample=config["sample"]),
         expand("seq/fastqc/{sample}_{reads}_fastqc.html", sample=config["sample"], reads=["R1", "R2"])
 
 
@@ -138,11 +138,11 @@ rule unicycler:
 
 rule quast:
     output:
-        report="analysis/quast/{assembler}/{sample}_report.html"
+        report="analysis/quast/{algorithm}/{sample}_report.html"
     input:
-        contigs="analysis/{assembler}/{sample}_contigs.fasta"
+        contigs="analysis/{algorithm}/{sample}_contigs.fasta"
     shell:
         """
-        quast.py {input.contigs} -o analysis/quast/{wildcards.assembler}
+        quast.py {input.contigs} -o analysis/quast/{wildcards.algorithm}
         ln -s report.html {output.report}
         """

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -100,9 +100,11 @@ rule spades:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz"
     threads: 128
+    params:
+        extra_args=config["extra_args"]
     shell:
         """
-        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades {config[extraargs][spades]}
+        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/spades {params.extra_args[spades]}
         ln -s scaffolds.fasta {output.contigs}
         """
 
@@ -114,9 +116,11 @@ rule megahit:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz"
     threads: 128
+    params:
+        extra_args=config["extra_args"]
     shell:
         """
-        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit-temp {config[extraargs][megahit]}
+        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/megahit-temp {params.extra_args[megahit]}
         mv analysis/megahit-temp/* analysis/megahit
         rm -r analysis/megahit-temp
         ln -s final.contigs.fa {output.contigs}
@@ -129,9 +133,11 @@ rule unicycler:
     input:
         read1="seq/downsample/{sample}.R1.fq.gz",
         read2="seq/downsample/{sample}.R2.fq.gz"
+    params:
+        extra_args=config["extra_args"]
     shell:
         """
-        unicycler -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/unicycler {config[extraargs][unicycler]}
+        unicycler -1 {input.read1} -2 {input.read2} -t {threads} -o analysis/unicycler {params.extra_args[unicycler]}
         ln -s assembly.fasta {output.contigs}
         """
 

--- a/yeat/__init__.py
+++ b/yeat/__init__.py
@@ -1,3 +1,12 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2021, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
 from ._version import get_versions
 
 __version__ = get_versions()["version"]

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -8,11 +8,31 @@
 # -------------------------------------------------------------------------------------------------
 
 import argparse
+from argparse import Action
+import json
 from pathlib import Path
 from pkg_resources import resource_filename
 from snakemake import snakemake
+import sys
 import yeat
 from yeat.config import AssemblerConfig
+
+
+class InitAction(Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        config = [
+            dict(
+                assembler="spades",
+                extra_args="",
+            ),
+            dict(
+                assembler="megahit",
+                extra_args="",
+            ),
+        ]
+        json.dump(config, sys.stdout, indent=4)
+        print()
+        raise SystemExit()
 
 
 def run(read1, read2, assemblers, outdir=".", cores=1, sample="sample", dryrun="dry"):
@@ -75,6 +95,12 @@ def get_parser():
         "--dry-run",
         action="store_true",
         help="construct workflow DAG and print a summary but do not execute",
+    )
+    parser.add_argument(
+        "--init",
+        action=InitAction,
+        nargs=0,
+        help="print a template assembly config file to the terminal (stdout) and exit",
     )
     parser.add_argument("config", type=str, help="configfile")
     parser.add_argument("reads", type=str, nargs=2, help="paired-end reads in FASTQ format")

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -18,7 +18,11 @@ from yeat.config import AssemblerConfig
 def run(read1, read2, assemblers, outdir=".", cores=1, sample="sample", dryrun="dry"):
     snakefile = resource_filename("yeat", "Snakefile")
     r1 = Path(read1).resolve()
+    if not r1.is_file():
+        raise FileNotFoundError(f"No such file: '{r1}'")
     r2 = Path(read2).resolve()
+    if not r2.is_file():
+        raise FileNotFoundError(f"No such file: '{r2}'")
     config = dict(
         read1=r1,
         read2=r2,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -45,13 +45,16 @@ def run(read1, read2, algorithms, outdir=".", cores=1, sample="sample", dryrun="
     r2 = Path(read2).resolve()
     if not r2.is_file():
         raise FileNotFoundError(f"No such file: '{r2}'")
+    assemblers = []
     extraargs = {}
-    for x in algorithms:
-        extraargs[x.algorithm] = x.extra_args
+    for algorithm in algorithms:
+        assembler = algorithm.algorithm
+        assemblers.append(assembler)
+        extraargs[assembler] = algorithm.extra_args
     config = dict(
         read1=r1,
         read2=r2,
-        algorithms=list(extraargs.keys()),
+        assemblers=assemblers,
         extraargs=extraargs,
         outdir=outdir,
         cores=cores,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -45,10 +45,14 @@ def run(read1, read2, algorithms, outdir=".", cores=1, sample="sample", dryrun="
     r2 = Path(read2).resolve()
     if not r2.is_file():
         raise FileNotFoundError(f"No such file: '{r2}'")
+    extraargs = {}
+    for x in algorithms:
+        extraargs[x.algorithm] = x.extra_args
     config = dict(
         read1=r1,
         read2=r2,
-        algorithms=algorithms,
+        algorithms=list(extraargs.keys()),
+        extraargs=extraargs,
         outdir=outdir,
         cores=cores,
         sample=sample,
@@ -113,7 +117,6 @@ def main(args=None):
     if args is None:
         args = get_parser().parse_args()
     algorithms = AssemblerConfig.parse_json(open(args.config))
-    algorithms = [x.algorithm for x in algorithms]
     run(
         *args.reads,
         algorithms=algorithms,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -63,7 +63,7 @@ def run(read1, read2, algorithms, outdir=".", cores=1, sample="sample", dryrun="
         workdir=outdir,
     )
     if not success:
-        raise RuntimeError("Snakemake Failed!")
+        raise RuntimeError("Snakemake Failed")
 
 
 def get_parser():

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -37,25 +37,21 @@ class InitAction(Action):
         raise SystemExit()
 
 
-def run(read1, read2, algorithms, outdir=".", cores=1, sample="sample", dryrun="dry"):
+def run(fastq1, fastq2, assembly_configs, outdir=".", cores=1, sample="sample", dryrun="dry"):
     snakefile = resource_filename("yeat", "Snakefile")
-    r1 = Path(read1).resolve()
+    r1 = Path(fastq1).resolve()
     if not r1.is_file():
         raise FileNotFoundError(f"No such file: '{r1}'")
-    r2 = Path(read2).resolve()
+    r2 = Path(fastq2).resolve()
     if not r2.is_file():
         raise FileNotFoundError(f"No such file: '{r2}'")
-    assemblers = []
-    extraargs = {}
-    for algorithm in algorithms:
-        assembler = algorithm.algorithm
-        assemblers.append(assembler)
-        extraargs[assembler] = algorithm.extra_args
+    assemblers = [config.algorithm for config in assembly_configs]
+    extra_args = {config.algorithm: config.extra_args for config in assembly_configs}
     config = dict(
         read1=r1,
         read2=r2,
         assemblers=assemblers,
-        extraargs=extraargs,
+        extra_args=extra_args,
         outdir=outdir,
         cores=cores,
         sample=sample,
@@ -119,10 +115,10 @@ def get_parser():
 def main(args=None):
     if args is None:
         args = get_parser().parse_args()
-    algorithms = AssemblerConfig.parse_json(open(args.config))
+    assembly_configs = AssemblerConfig.parse_json(open(args.config))
     run(
         *args.reads,
-        algorithms=algorithms,
+        assembly_configs=assembly_configs,
         outdir=args.outdir,
         cores=args.threads,
         sample=args.sample,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -20,12 +20,12 @@ from yeat.config import AssemblerConfig
 
 CONFIG_TEMPLATE = [
     dict(
-        assembler="spades",
-        extra_args="",
+        algorithm="spades",
+        extra_args="--meta",
     ),
     dict(
-        assembler="megahit",
-        extra_args="",
+        algorithm="megahit",
+        extra_args="--min-count 5 --min-contig-len 300",
     ),
 ]
 
@@ -37,7 +37,7 @@ class InitAction(Action):
         raise SystemExit()
 
 
-def run(read1, read2, assemblers, outdir=".", cores=1, sample="sample", dryrun="dry"):
+def run(read1, read2, algorithms, outdir=".", cores=1, sample="sample", dryrun="dry"):
     snakefile = resource_filename("yeat", "Snakefile")
     r1 = Path(read1).resolve()
     if not r1.is_file():
@@ -48,7 +48,7 @@ def run(read1, read2, assemblers, outdir=".", cores=1, sample="sample", dryrun="
     config = dict(
         read1=r1,
         read2=r2,
-        assemblers=assemblers,
+        algorithms=algorithms,
         outdir=outdir,
         cores=cores,
         sample=sample,
@@ -112,11 +112,11 @@ def get_parser():
 def main(args=None):
     if args is None:
         args = get_parser().parse_args()
-    assemblers = AssemblerConfig.parse_json(open(args.config))
-    assemblers = [x.assembler for x in assemblers]
+    algorithms = AssemblerConfig.parse_json(open(args.config))
+    algorithms = [x.algorithm for x in algorithms]
     run(
         *args.reads,
-        assemblers=assemblers,
+        algorithms=algorithms,
         outdir=args.outdir,
         cores=args.threads,
         sample=args.sample,

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -18,19 +18,21 @@ import yeat
 from yeat.config import AssemblerConfig
 
 
+CONFIG_TEMPLATE = [
+    dict(
+        assembler="spades",
+        extra_args="",
+    ),
+    dict(
+        assembler="megahit",
+        extra_args="",
+    ),
+]
+
+
 class InitAction(Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        config = [
-            dict(
-                assembler="spades",
-                extra_args="",
-            ),
-            dict(
-                assembler="megahit",
-                extra_args="",
-            ),
-        ]
-        json.dump(config, sys.stdout, indent=4)
+        json.dump(CONFIG_TEMPLATE, sys.stdout, indent=4)
         print()
         raise SystemExit()
 
@@ -61,7 +63,7 @@ def run(read1, read2, assemblers, outdir=".", cores=1, sample="sample", dryrun="
         workdir=outdir,
     )
     if not success:
-        raise RuntimeError("Snakemake Failed")
+        raise RuntimeError("Snakemake Failed!")
 
 
 def get_parser():

--- a/yeat/config.py
+++ b/yeat/config.py
@@ -7,7 +7,6 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
-
 import json
 from warnings import warn
 

--- a/yeat/config.py
+++ b/yeat/config.py
@@ -1,0 +1,75 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2022, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+
+import json
+from warnings import warn
+
+
+ASSEMBLY_ALGORITHMS = ["spades", "megahit", "unicycler"]
+
+
+class AssemblerConfigError(ValueError):
+    pass
+
+
+class AssemblerConfig:
+    def __init__(self, assembler, extra_args=""):
+        self.assembler = assembler
+        self.extra_args = extra_args
+
+    @classmethod
+    def from_json(cls, data):
+        return cls(data["assembler"], data["extra_args"])
+
+    @staticmethod
+    def parse_json(instream):
+        data = json.load(instream)
+        algorithms = set()
+        assemblers = []
+        for d in data:
+            AssemblerConfig.validate_config(d)
+            algorithm = d["assembler"]
+            AssemblerConfig.check_algorithm(algorithm, algorithms)
+            algorithms.add(algorithm)
+            assemblers.append(AssemblerConfig.from_json(d))
+        return assemblers
+
+    @staticmethod
+    def check_algorithm(algorithm, algorithms):
+        if algorithm not in ASSEMBLY_ALGORITHMS:
+            message = (
+                f"Found unsupported assembly algorithm with `--assemblers` flag: [[{algorithm}]]!"
+            )
+            raise ValueError(message)
+        if algorithm in algorithms:
+            message = (
+                f"Found duplicate assembly algorithm with `--assemblers` flag: [[{algorithm}]]!"
+            )
+            warn(message)
+
+    @staticmethod
+    def validate_config(config):
+        expectedkeys = ("assembler", "extra_args")
+        missingkeys = set()
+        extrakeys = set()
+        for key in expectedkeys:
+            if key not in config:
+                missingkeys.add(key)
+        for key in config:
+            if key not in expectedkeys:
+                extrakeys.add(key)
+        if len(missingkeys) > 0:
+            keystr = ",".join(sorted(missingkeys))
+            message = f"Missing assembly configuration setting(s): {keystr}"
+            raise AssemblerConfigError(message)
+        if len(extrakeys) > 0:
+            keystr = ",".join(sorted(extrakeys))
+            message = f"Ignoring unsupported configuration key(s): {keystr}"
+            warn(message)

--- a/yeat/config.py
+++ b/yeat/config.py
@@ -11,60 +11,45 @@ import json
 from warnings import warn
 
 
-ASSEMBLY_ALGORITHMS = ["spades", "megahit", "unicycler"]
+ALGORITHMS = ("spades", "megahit", "unicycler")
 
 
-class AssemblerConfigError(ValueError):
+class AssemblyConfigurationError(ValueError):
     pass
 
 
 class AssemblerConfig:
-    def __init__(self, assembler, extra_args=""):
-        self.assembler = assembler
+    def __init__(self, algorithm, extra_args=""):
+        if algorithm not in ALGORITHMS:
+            raise AssemblyConfigurationError(f"Unsupported assembly algorithm '{algorithm}'")
+        self.algorithm = algorithm
         self.extra_args = extra_args
 
     @classmethod
     def from_json(cls, data):
-        return cls(data["assembler"], data["extra_args"])
+        return cls(data["algorithm"], data["extra_args"])
 
     @staticmethod
     def parse_json(instream):
-        data = json.load(instream)
-        algorithms = set()
-        assemblers = []
-        for d in data:
-            AssemblerConfig.validate_config(d)
-            algorithm = d["assembler"]
-            AssemblerConfig.check_algorithm(algorithm, algorithms)
-            algorithms.add(algorithm)
-            assemblers.append(AssemblerConfig.from_json(d))
-        return assemblers
+        configdata = json.load(instream)
+        for entry in configdata:
+            AssemblerConfig.validate(entry)
+        algorithms = [entry["algorithm"] for entry in configdata]
+        if len(algorithms) > len(set(algorithms)):
+            message = "Duplicate assembly configuration: please check config file"
+            raise AssemblyConfigurationError(message)
+        configlist = [AssemblerConfig.from_json(entry) for entry in configdata]
+        return configlist
 
     @staticmethod
-    def check_algorithm(algorithm, algorithms):
-        if algorithm not in ASSEMBLY_ALGORITHMS:
-            message = f"Found unsupported assembly algorithm in config settings: [[{algorithm}]]!"
-            raise ValueError(message)
-        if algorithm in algorithms:
-            message = f"Found duplicate assembly algorithm in config settings: [[{algorithm}]]!"
-            raise ValueError(message)
-
-    @staticmethod
-    def validate_config(config):
-        expectedkeys = ("assembler", "extra_args")
-        missingkeys = set()
-        extrakeys = set()
-        for key in expectedkeys:
-            if key not in config:
-                missingkeys.add(key)
-        for key in config:
-            if key not in expectedkeys:
-                extrakeys.add(key)
+    def validate(config):
+        missingkeys = set(["algorithm", "extra_args"]) - set(config.keys())
+        extrakeys = set(config.keys()) - set(["algorithm", "extra_args"])
         if len(missingkeys) > 0:
             keystr = ",".join(sorted(missingkeys))
-            message = f"Missing assembly configuration setting(s): [[{keystr}]]!"
-            raise AssemblerConfigError(message)
+            message = f"Missing assembly configuration setting(s) '{keystr}'"
+            raise AssemblyConfigurationError(message)
         if len(extrakeys) > 0:
             keystr = ",".join(sorted(extrakeys))
-            message = f"Ignoring unsupported configuration key(s): [[{keystr}]]!"
+            message = f"Ignoring unsupported configuration key(s) '{keystr}'"
             warn(message)

--- a/yeat/config.py
+++ b/yeat/config.py
@@ -43,14 +43,10 @@ class AssemblerConfig:
     @staticmethod
     def check_algorithm(algorithm, algorithms):
         if algorithm not in ASSEMBLY_ALGORITHMS:
-            message = (
-                f"Found unsupported assembly algorithm in configuration settings: [[{algorithm}]]!"
-            )
+            message = f"Found unsupported assembly algorithm in config settings: [[{algorithm}]]!"
             raise ValueError(message)
         if algorithm in algorithms:
-            message = (
-                f"Found duplicate assembly algorithm in configuration settings: [[{algorithm}]]!"
-            )
+            message = f"Found duplicate assembly algorithm in config settings: [[{algorithm}]]!"
             raise ValueError(message)
 
     @staticmethod
@@ -66,9 +62,9 @@ class AssemblerConfig:
                 extrakeys.add(key)
         if len(missingkeys) > 0:
             keystr = ",".join(sorted(missingkeys))
-            message = f"Missing assembly configuration setting(s): {keystr}"
+            message = f"Missing assembly configuration setting(s): [[{keystr}]]!"
             raise AssemblerConfigError(message)
         if len(extrakeys) > 0:
             keystr = ",".join(sorted(extrakeys))
-            message = f"Ignoring unsupported configuration key(s): {keystr}"
+            message = f"Ignoring unsupported configuration key(s): [[{keystr}]]!"
             warn(message)

--- a/yeat/config.py
+++ b/yeat/config.py
@@ -44,14 +44,14 @@ class AssemblerConfig:
     def check_algorithm(algorithm, algorithms):
         if algorithm not in ASSEMBLY_ALGORITHMS:
             message = (
-                f"Found unsupported assembly algorithm with `--assemblers` flag: [[{algorithm}]]!"
+                f"Found unsupported assembly algorithm in configuration settings: [[{algorithm}]]!"
             )
             raise ValueError(message)
         if algorithm in algorithms:
             message = (
-                f"Found duplicate assembly algorithm with `--assemblers` flag: [[{algorithm}]]!"
+                f"Found duplicate assembly algorithm in configuration settings: [[{algorithm}]]!"
             )
-            warn(message)
+            raise ValueError(message)
 
     @staticmethod
     def validate_config(config):

--- a/yeat/tests/__init__.py
+++ b/yeat/tests/__init__.py
@@ -1,3 +1,12 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2021, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
 import os
 from pkg_resources import resource_filename
 

--- a/yeat/tests/data/config.cfg
+++ b/yeat/tests/data/config.cfg
@@ -1,0 +1,10 @@
+[
+    {
+        "assembler": "spades",
+        "extra_args": ""
+    },
+    {
+        "assembler": "megahit",
+        "extra_args": ""
+    }
+]

--- a/yeat/tests/data/dup_algorithms.cfg
+++ b/yeat/tests/data/dup_algorithms.cfg
@@ -4,7 +4,7 @@
         "extra_args": ""
     },
     {
-        "algorithm": "megahit",
+        "algorithm": "spades",
         "extra_args": ""
     }
 ]

--- a/yeat/tests/data/unicycler.cfg
+++ b/yeat/tests/data/unicycler.cfg
@@ -1,6 +1,6 @@
 [
     {
-        "assembler": "unicycler",
+        "algorithm": "unicycler",
         "extra_args": ""
     }
 ]

--- a/yeat/tests/data/unicycler.cfg
+++ b/yeat/tests/data/unicycler.cfg
@@ -1,0 +1,6 @@
+[
+    {
+        "assembler": "unicycler",
+        "extra_args": ""
+    }
+]

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -13,8 +13,8 @@ from yeat import cli
 from yeat.tests import data_file
 
 
-# the purpose of this test is to check if the snakemake workflow is properly defined.
 def test_basic_dry_run(tmp_path):
+    """The purpose of this test is to check if the snakemake workflow is properly defined."""
     wd = str(tmp_path)
     arglist = [
         data_file("config.cfg"),
@@ -35,37 +35,35 @@ def test_no_args():
         cli.main(None)
 
 
-def test_snakemake_fail_because_of_invalid_read_files():
-    with pytest.raises(Exception, match=r"Snakemake Failed"):
+def test_invalid_read_files():
+    with pytest.raises(Exception, match=r"No such file:.*read1\'"):
         read1 = "read1"
         read2 = "read2"
-        assemblers = "spades"
+        assemblers = ["spades"]
         cli.run(read1, read2, assemblers)
 
 
-# def test_unsupported_assembly_algorithm():
-#     assemblers = ["unsupported_assembly"]
-#     error_message = r"Found unsupported assembly algorithm with `--assemblers` flag: \[\[unsupported_assembly\]\]!"
-#     with pytest.raises(ValueError, match=error_message):
-#         cli.check_assemblers(assemblers)
-
-
-# def test_duplicate_assembly_algorithms():
-#     assemblers = ["spades", "spades"]
-#     error_message = r"Found duplicate assembly algorithm with `--assemblers` flag: \[\[spades\]\]!"
-#     with pytest.raises(ValueError, match=error_message):
-#         cli.check_assemblers(assemblers)
-
-
-
-# test for algorithms that I didn't say to run but doens't exist in config
-# for example, i want unicycler but it never ran unicycler
-
-
-def test_unicycler(capsys, tmp_path):
+def test_multiple_assemblers(tmp_path):
     wd = str(tmp_path)
     arglist = [
         data_file("config.cfg"),
+        data_file("short_reads_1.fastq.gz"),
+        data_file("short_reads_2.fastq.gz"),
+        "--outdir",
+        wd,
+    ]
+    args = cli.get_parser().parse_args(arglist)
+    cli.main(args)
+    spades_result = Path(wd).resolve() / "analysis" / "spades" / "contigs.fasta"
+    assert spades_result.exists()
+    megahit_result = Path(wd).resolve() / "analysis" / "megahit" / "final.contigs.fa"
+    assert megahit_result.exists()
+
+
+def test_unicycler(tmp_path):
+    wd = str(tmp_path)
+    arglist = [
+        data_file("unicycler.cfg"),
         data_file("short_reads_1.fastq.gz"),
         data_file("short_reads_2.fastq.gz"),
         "--outdir",

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -9,7 +9,6 @@
 
 from pathlib import Path
 import pytest
-import yeat
 from yeat import cli
 from yeat.tests import data_file
 
@@ -18,23 +17,22 @@ from yeat.tests import data_file
 def test_basic_dry_run(tmp_path):
     wd = str(tmp_path)
     arglist = [
+        data_file("config.cfg"),
         data_file("Animal_289_R1.fq.gz"),
         data_file("Animal_289_R2.fq.gz"),
-        "--assemblers",
-        "spades",
         "--outdir",
         wd,
         "--sample",
         "Animal_289",
         "-n",
     ]
-    args = yeat.cli.get_parser().parse_args(arglist)
-    yeat.cli.main(args)
+    args = cli.get_parser().parse_args(arglist)
+    cli.main(args)
 
 
 def test_no_args():
     with pytest.raises(SystemExit, match=r"2"):
-        yeat.cli.main(None)
+        cli.main(None)
 
 
 def test_snakemake_fail_because_of_invalid_read_files():
@@ -42,34 +40,38 @@ def test_snakemake_fail_because_of_invalid_read_files():
         read1 = "read1"
         read2 = "read2"
         assemblers = "spades"
-        yeat.cli.run(read1, read2, assemblers)
+        cli.run(read1, read2, assemblers)
 
 
-def test_unsupported_assembly_algorithm():
-    assemblers = ["unsupported_assembly"]
-    error_message = r"Found unsupported assembly algorithm with `--assemblers` flag: \[\[unsupported_assembly\]\]!"
-    with pytest.raises(ValueError, match=error_message):
-        yeat.cli.check_assemblers(assemblers)
+# def test_unsupported_assembly_algorithm():
+#     assemblers = ["unsupported_assembly"]
+#     error_message = r"Found unsupported assembly algorithm with `--assemblers` flag: \[\[unsupported_assembly\]\]!"
+#     with pytest.raises(ValueError, match=error_message):
+#         cli.check_assemblers(assemblers)
 
 
-def test_duplicate_assembly_algorithms():
-    assemblers = ["spades", "spades"]
-    error_message = r"Found duplicate assembly algorithm with `--assemblers` flag: \[\[spades\]\]!"
-    with pytest.raises(ValueError, match=error_message):
-        yeat.cli.check_assemblers(assemblers)
+# def test_duplicate_assembly_algorithms():
+#     assemblers = ["spades", "spades"]
+#     error_message = r"Found duplicate assembly algorithm with `--assemblers` flag: \[\[spades\]\]!"
+#     with pytest.raises(ValueError, match=error_message):
+#         cli.check_assemblers(assemblers)
+
+
+
+# test for algorithms that I didn't say to run but doens't exist in config
+# for example, i want unicycler but it never ran unicycler
 
 
 def test_unicycler(capsys, tmp_path):
     wd = str(tmp_path)
     arglist = [
+        data_file("config.cfg"),
         data_file("short_reads_1.fastq.gz"),
         data_file("short_reads_2.fastq.gz"),
-        "--assemblers",
-        "unicycler",
         "--outdir",
         wd,
     ]
-    args = yeat.cli.get_parser().parse_args(arglist)
-    yeat.cli.main(args)
+    args = cli.get_parser().parse_args(arglist)
+    cli.main(args)
     assembly_result = Path(wd).resolve() / "analysis" / "unicycler" / "assembly.fasta"
     assert assembly_result.exists()

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -7,10 +7,19 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
+import json
 from pathlib import Path
 import pytest
 from yeat import cli
+from yeat.cli import InitAction
 from yeat.tests import data_file
+
+
+def test_display_config_template(capsys):
+    with pytest.raises(SystemExit):
+        InitAction.__call__(None, None, None, None)
+    out, err = capsys.readouterr()
+    assert json.loads(out) == cli.CONFIG_TEMPLATE
 
 
 def test_basic_dry_run(tmp_path):
@@ -35,7 +44,7 @@ def test_no_args():
         cli.main(None)
 
 
-def test_invalid_read_files():
+def test_invalid_read1_file():
     with pytest.raises(Exception, match=r"No such file:.*read1\'"):
         read1 = "read1"
         read2 = "read2"
@@ -43,7 +52,15 @@ def test_invalid_read_files():
         cli.run(read1, read2, assemblers)
 
 
-def test_multiple_assemblers(tmp_path):
+def test_invalid_read2_file():
+    with pytest.raises(Exception, match=r"No such file:.*read2\'"):
+        read1 = data_file("short_reads_1.fastq.gz")
+        read2 = "read2"
+        assemblers = ["spades"]
+        cli.run(read1, read2, assemblers)
+
+
+def test_multiple_assemblers(capsys, tmp_path):
     wd = str(tmp_path)
     arglist = [
         data_file("config.cfg"),
@@ -60,7 +77,7 @@ def test_multiple_assemblers(tmp_path):
     assert megahit_result.exists()
 
 
-def test_unicycler(tmp_path):
+def test_unicycler(capsys, tmp_path):
     wd = str(tmp_path)
     arglist = [
         data_file("unicycler.cfg"),

--- a/yeat/tests/test_config.py
+++ b/yeat/tests/test_config.py
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2022, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+from yeat.config import AssemblerConfig
+
+
+def test_unsupported_assembly_algorithm():
+    algorithm = "unsupported_algorithm"
+    pattern = (
+        rf"Found unsupported assembly algorithm in configuration settings: \[\[{algorithm}\]\]!"
+    )
+    with pytest.raises(ValueError, match=pattern):
+        AssemblerConfig.check_algorithm(algorithm, [])
+
+
+def test_duplicate_assembly_algorithms():
+    algorithm = "spades"
+    pattern = (
+        rf"Found duplicate assembly algorithm in configuration settings: \[\[{algorithm}\]\]!"
+    )
+    with pytest.raises(ValueError, match=pattern):
+        AssemblerConfig.check_algorithm(algorithm, ["spades"])

--- a/yeat/tests/test_config.py
+++ b/yeat/tests/test_config.py
@@ -8,22 +8,44 @@
 # -------------------------------------------------------------------------------------------------
 
 import pytest
-from yeat.config import AssemblerConfig
+from yeat.config import AssemblerConfig, AssemblerConfigError
+from yeat.tests import data_file
 
 
 def test_unsupported_assembly_algorithm():
     algorithm = "unsupported_algorithm"
-    pattern = (
-        rf"Found unsupported assembly algorithm in configuration settings: \[\[{algorithm}\]\]!"
-    )
+    pattern = rf"Found unsupported assembly algorithm in config settings: \[\[{algorithm}]]!"
     with pytest.raises(ValueError, match=pattern):
         AssemblerConfig.check_algorithm(algorithm, [])
 
 
 def test_duplicate_assembly_algorithms():
     algorithm = "spades"
-    pattern = (
-        rf"Found duplicate assembly algorithm in configuration settings: \[\[{algorithm}\]\]!"
-    )
+    pattern = rf"Found duplicate assembly algorithm in config settings: \[\[{algorithm}]]!"
     with pytest.raises(ValueError, match=pattern):
         AssemblerConfig.check_algorithm(algorithm, ["spades"])
+
+
+def test_parse_json():
+    f = open(data_file("config.cfg"))
+    assemblers = [x.assembler for x in AssemblerConfig.parse_json(f)]
+    assert assemblers == ["spades", "megahit"]
+
+
+def test_valid_config_entry():
+    data = {"assembler": "spades", "extra_args": ""}
+    AssemblerConfig.validate_config(data)
+
+
+def test_missing_key_in_config_entry():
+    data = {"extra_args": ""}
+    pattern = r"Missing assembly configuration setting\(s\): \[\[assembler]]!"
+    with pytest.raises(AssemblerConfigError, match=pattern):
+        AssemblerConfig.validate_config(data)
+
+
+def test_unsupported_key_in_config_entry():
+    data = {"assembler": "spades", "extra_args": "", "not": "supported"}
+    pattern = r"Ignoring unsupported configuration key\(s\): \[\[not]]!"
+    with pytest.warns(match=pattern):
+        AssemblerConfig.validate_config(data)


### PR DESCRIPTION
The purpose of this PR is to allow users to create their own assembly config file.

An example of the config file can be seen by executing `yeat --init`, which will pull up:
```
[
    {
        "assembler": "spades",
        "extra_args": ""
    },
    {
        "assembler": "megahit",
        "extra_args": ""
    }
]
```
