### PR TITLE
Adding custom downsample flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Unicycler (#14)
 - Support for assembly configuration file (#16)
 - Commands to run a short or long test suite (#20)
+- Custom downsampling flag (#21)
 
 
 ## [0.1] 2021-12-01

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -79,15 +79,21 @@ rule downsample:
         read1="seq/fastp/{sample}.R1.fq.gz",
         read2="seq/fastp/{sample}.R2.fq.gz",
         mash_report="seq/mash/{sample}.report.tsv"
+    params:
+        downsample=config["downsample"]
     run:
         result = input.mash_report
         df = pd.read_csv(result, sep="\t")
         genome_size = df["Length"].iloc[0]
-        coverage = 150
-        read_length = 250
-        down = (genome_size * 150) // (2 * read_length)
         print(f"genome size: {genome_size}")
-        print(f"down: {down}")
+        if params.downsample == 0:
+            coverage = 150
+            read_length = 250
+            down = (genome_size * coverage) // (2 * read_length)
+            print(f"auto down: {down}")
+        else:
+            down = params.downsample
+            print(f"custom down: {down}")
         shell("seqtk sample {input.read1} {down} > seq/downsample/{wildcards.sample}.R1.fq")
         shell("seqtk sample {input.read2} {down} > seq/downsample/{wildcards.sample}.R2.fq")
         shell("gzip -f seq/downsample/*")

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -9,6 +9,7 @@
 
 from shutil import copyfile
 import pandas as pd
+from pathlib import Path
 
 
 rule all:
@@ -82,10 +83,16 @@ rule downsample:
     params:
         downsample=config["downsample"]
     run:
+        if params.downsample == -1:
+            p = Path("seq/downsample")
+            p.mkdir(parents=True, exist_ok=True)
+            copyfile(input.read1, output.sub1)
+            copyfile(input.read2, output.sub2)
+            return
         result = input.mash_report
         df = pd.read_csv(result, sep="\t")
         genome_size = df["Length"].iloc[0]
-        print(f"genome size: {genome_size}")
+        print(f"genome size: {genome_size}")    
         if params.downsample == 0:
             coverage = 150
             read_length = 250

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -117,7 +117,7 @@ def get_parser():
         type=int,
         metavar="D",
         default=0,
-        help="downsample reads down to a custom number; by default, D=0; when no value is given, YEAT will auto-downsample",
+        help="downsample reads down to a custom number; by default, D=0; when set to default, YEAT will auto downsample; set D=-1 to not downsample",
     )
     parser.add_argument(
         "--init",

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -117,7 +117,7 @@ def get_parser():
         type=int,
         metavar="D",
         default=0,
-        help="downsample reads down to a custom number; by default, D=0; when set to default, YEAT will auto downsample; set D=-1 to not downsample",
+        help="downsample reads down to the desired number; by default, D=0; when set to default, YEAT will auto downsample; set D=-1 to not downsample",
     )
     parser.add_argument(
         "--init",

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -37,7 +37,16 @@ class InitAction(Action):
         raise SystemExit()
 
 
-def run(fastq1, fastq2, assembly_configs, outdir=".", cores=1, sample="sample", dryrun="dry"):
+def run(
+    fastq1,
+    fastq2,
+    assembly_configs,
+    outdir=".",
+    cores=1,
+    sample="sample",
+    dryrun="dry",
+    downsample=0,
+):
     snakefile = resource_filename("yeat", "Snakefile")
     r1 = Path(fastq1).resolve()
     if not r1.is_file():
@@ -56,6 +65,7 @@ def run(fastq1, fastq2, assembly_configs, outdir=".", cores=1, sample="sample", 
         cores=cores,
         sample=sample,
         dryrun=dryrun,
+        downsample=downsample,
     )
     success = snakemake(
         snakefile,
@@ -102,6 +112,14 @@ def get_parser():
         help="construct workflow DAG and print a summary but do not execute",
     )
     parser.add_argument(
+        "-d",
+        "--downsample",
+        type=int,
+        metavar="D",
+        default=0,
+        help="downsample reads down to a custom number; by default, D=0; when no value is given, YEAT will auto-downsample",
+    )
+    parser.add_argument(
         "--init",
         action=InitAction,
         nargs=0,
@@ -123,4 +141,5 @@ def main(args=None):
         cores=args.threads,
         sample=args.sample,
         dryrun=args.dry_run,
+        downsample=args.downsample,
     )

--- a/yeat/config.py
+++ b/yeat/config.py
@@ -12,6 +12,7 @@ from warnings import warn
 
 
 ALGORITHMS = ("spades", "megahit", "unicycler")
+KEYS = ["algorithm", "extra_args"]
 
 
 class AssemblyConfigurationError(ValueError):
@@ -43,8 +44,8 @@ class AssemblerConfig:
 
     @staticmethod
     def validate(config):
-        missingkeys = set(["algorithm", "extra_args"]) - set(config.keys())
-        extrakeys = set(config.keys()) - set(["algorithm", "extra_args"])
+        missingkeys = set(KEYS) - set(config.keys())
+        extrakeys = set(config.keys()) - set(KEYS)
         if len(missingkeys) > 0:
             keystr = ",".join(sorted(missingkeys))
             message = f"Missing assembly configuration setting(s) '{keystr}'"

--- a/yeat/tests/data/config.cfg
+++ b/yeat/tests/data/config.cfg
@@ -1,10 +1,10 @@
 [
     {
         "algorithm": "spades",
-        "extra_args": ""
+        "extra_args": "--meta"
     },
     {
         "algorithm": "megahit",
-        "extra_args": ""
+        "extra_args": "--min-count 5 --min-contig-len 300"
     }
 ]

--- a/yeat/tests/data/megahit.cfg
+++ b/yeat/tests/data/megahit.cfg
@@ -1,0 +1,6 @@
+[
+    {
+        "algorithm": "megahit",
+        "extra_args": ""
+    }
+]


### PR DESCRIPTION
The purpose of this PR is to resolve #17 .

Originally, YEAT would automatically downsample to a x150 coverage. In this PR, a new option was added for users to input their own custom downsampling number using the `-d` flag.

From my understanding, depending on certain situations, not all reads should conform to an estimated downsample number because you might need more or less total reads.