### PR TITLE
Adding `--genome-size` flag to override auto-calculated genome size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Commands to run a short or long test suite (#20)
 - Custom downsampling flag (#21)
 - Custom coverage flag (#23)
+- Custom genome size flag (#30)
 
 
 ## [0.1] 2021-12-01

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -86,7 +86,7 @@ rule downsample:
         coverage=config["coverage"],
         downsample=config["downsample"],
         fastp_report="seq/fastp/fastp.json",
-        genome_size=config["genomesize"]
+        genome_size=config["genomesize"],
         seed=config["seed"]
     run:
         if params.downsample == -1:

--- a/yeat/Snakefile
+++ b/yeat/Snakefile
@@ -85,7 +85,8 @@ rule downsample:
     params:
         coverage=config["coverage"],
         downsample=config["downsample"],
-        fastp_report="seq/fastp/fastp.json"
+        fastp_report="seq/fastp/fastp.json",
+        genome_size=config["genomesize"]
     run:
         if params.downsample == -1:
             p = Path("seq/downsample")
@@ -93,9 +94,11 @@ rule downsample:
             copyfile(input.read1, output.sub1)
             copyfile(input.read2, output.sub2)
             return
-        df = pd.read_csv(input.mash_report, sep="\t")
-        genome_size = df["Length"].iloc[0]
-        print(f"genome size: {genome_size}")
+        if params.genome_size == 0:
+            df = pd.read_csv(input.mash_report, sep="\t")
+            genome_size = df["Length"].iloc[0]
+        else:
+            genome_size = params.genome_size
         with open(params.fastp_report, "r") as fh:
             qcdata = json.load(fh)
         base_count = qcdata["summary"]["after_filtering"]["total_bases"]
@@ -106,6 +109,7 @@ rule downsample:
         else:
             down = params.downsample
         seed = randint(1, 2**16-1)
+        print(f"[yeat] genome size: {genome_size}")
         print(f"[yeat] average read length: {avg_read_length}")
         print(f"[yeat] target depth of coverage: {params.coverage}x")
         print(f"[yeat] number of reads to sample: {down}")

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -146,7 +146,7 @@ def get_parser(exit_on_error=True):
         type=int,
         metavar="G",
         default=0,
-        help="genome size; by default, G=0",
+        help="provide known genome size in base pairs (bp); by default, G=0",
     )
     parser.add_argument(
         "--init",

--- a/yeat/cli.py
+++ b/yeat/cli.py
@@ -46,6 +46,7 @@ def run(
     dryrun="dry",
     downsample=0,
     coverage=150,
+    genomesize=0,
 ):
     snakefile = resource_filename("yeat", "Snakefile")
     r1 = Path(fastq1).resolve()
@@ -67,6 +68,7 @@ def run(
         dryrun=dryrun,
         downsample=downsample,
         coverage=coverage,
+        genomesize=genomesize,
     )
     success = snakemake(
         snakefile,
@@ -139,6 +141,14 @@ def get_parser(exit_on_error=True):
         help="target an average depth of coverage Cx when auto-downsampling; by default, C=150",
     )
     parser.add_argument(
+        "-g",
+        "--genome-size",
+        type=int,
+        metavar="G",
+        default=0,
+        help="genome size; by default, G=0",
+    )
+    parser.add_argument(
         "--init",
         action=InitAction,
         nargs=0,
@@ -162,4 +172,5 @@ def main(args=None):
         dryrun=args.dry_run,
         downsample=args.downsample,
         coverage=args.coverage,
+        genomesize=args.genome_size,
     )


### PR DESCRIPTION
The purpose of this PR is to resolve #28 .

Sometimes, when YEAT auto calculates the genome size with MASH, the value can be off or if the user knows exactly the genome size, it's better to go with that number when appropriate.

In this PR, users can call the `--genome-size` flag to override YEAT's auto calculated size with the user's input.