### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/yeat/tests/__init__.py
+++ b/yeat/tests/__init__.py
@@ -9,15 +9,13 @@
 
 import json
 import multiprocessing
-import os
 from pathlib import Path
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 
 def data_file(path):
-    pathparts = path.split("/")
-    relpath = os.path.join("tests", "data", *pathparts)
-    return resource_filename("yeat", relpath)
+    pkg_path = files("yeat") / "tests" / "data" / path
+    return str(pkg_path)
 
 
 def get_core_count():
@@ -35,7 +33,7 @@ def write_config(labels, wd, cfg):
     return assemblers
 
 
-def files_exists(wd, assemblers, expected):
+def files_exist(wd, assemblers, expected):
     analysis_dir = Path(wd).resolve() / "analysis"
     for assembler in assemblers:
         for sample in assembler["samples"]:

--- a/yeat/tests/test_oxford.py
+++ b/yeat/tests/test_oxford.py
@@ -10,7 +10,7 @@
 from pathlib import Path
 import pytest
 from yeat import cli
-from yeat.tests import data_file, get_core_count, write_config, files_exists
+from yeat.tests import data_file, get_core_count, write_config, files_exist
 
 
 def test_oxford_nanopore_assemblers_dry_run(tmp_path):
@@ -36,4 +36,4 @@ def test_oxford_nanopore_read_assemblers(labels, expected, capsys, tmp_path):
     arglist = ["-o", wd, "-t", cores, cfg]
     args = cli.get_parser().parse_args(arglist)
     cli.main(args)
-    files_exists(wd, assemblers, expected)
+    files_exist(wd, assemblers, expected)

--- a/yeat/tests/test_pacbio.py
+++ b/yeat/tests/test_pacbio.py
@@ -10,7 +10,7 @@
 from pathlib import Path
 import pytest
 from yeat import cli
-from yeat.tests import data_file, get_core_count, write_config, files_exists
+from yeat.tests import data_file, get_core_count, write_config, files_exist
 
 
 def test_pacbio_hifi_assemblers_dry_run(tmp_path):
@@ -37,7 +37,7 @@ def test_pacbio_hifi_read_assemblers(labels, expected, capsys, tmp_path):
     arglist = ["-o", wd, "-t", cores, cfg]
     args = cli.get_parser().parse_args(arglist)
     cli.main(args)
-    files_exists(wd, assemblers, expected)
+    files_exist(wd, assemblers, expected)
 
 
 @pytest.mark.hifi
@@ -56,4 +56,4 @@ def test_pacbio_hifi_read_metagenomic_assemblers(labels, expected, capsys, tmp_p
     arglist = ["-o", wd, "-t", cores, cfg]
     args = cli.get_parser().parse_args(arglist)
     cli.main(args)
-    files_exists(wd, assemblers, expected)
+    files_exist(wd, assemblers, expected)

--- a/yeat/tests/test_paired.py
+++ b/yeat/tests/test_paired.py
@@ -14,7 +14,7 @@ import pytest
 import re
 import subprocess
 from yeat import cli
-from yeat.tests import data_file, write_config, files_exists
+from yeat.tests import data_file, write_config, files_exist
 
 
 def test_paired_end_assemblers_dry_run(tmp_path):
@@ -40,7 +40,7 @@ def test_paired_end_assemblers(labels, expected, capsys, tmp_path):
     arglist = ["-o", wd, cfg]
     args = cli.get_parser().parse_args(arglist)
     cli.main(args)
-    files_exists(wd, assemblers, expected)
+    files_exist(wd, assemblers, expected)
 
 
 @pytest.mark.long

--- a/yeat/tests/test_single.py
+++ b/yeat/tests/test_single.py
@@ -10,7 +10,7 @@
 from pathlib import Path
 import pytest
 from yeat import cli
-from yeat.tests import data_file, write_config, files_exists
+from yeat.tests import data_file, write_config, files_exist
 
 
 def test_single_end_assemblers_dry_run(tmp_path):
@@ -36,4 +36,4 @@ def test_single_end_assemblers(labels, expected, capsys, tmp_path):
     arglist = ["-o", wd, cfg]
     args = cli.get_parser().parse_args(arglist)
     cli.main(args)
-    files_exists(wd, assemblers, expected)
+    files_exist(wd, assemblers, expected)

--- a/yeat/workflows/__init__.py
+++ b/yeat/workflows/__init__.py
@@ -8,12 +8,12 @@
 # -------------------------------------------------------------------------------------------------
 
 from . import bandage
-from pkg_resources import resource_filename
+from importlib.resources import files
 from snakemake import snakemake
 
 
 def run_paired(args, config):
-    snakefile = resource_filename("yeat", "workflows/snakefiles/Paired")
+    snakefile = files("yeat") / "workflows" / "snakefiles" / "Paired"
     data = config.to_dict(args, readtype="paired")
     success = snakemake(
         snakefile,
@@ -28,7 +28,7 @@ def run_paired(args, config):
 
 
 def run_single(args, config):
-    snakefile = resource_filename("yeat", "workflows/snakefiles/Single")
+    snakefile = files("yeat") / "workflows" / "snakefiles" / "Single"
     data = config.to_dict(args, readtype="single")
     success = snakemake(
         snakefile,
@@ -43,7 +43,7 @@ def run_single(args, config):
 
 
 def run_pacbio(args, config):
-    snakefile = resource_filename("yeat", "workflows/snakefiles/Pacbio")
+    snakefile = files("yeat") / "workflows" / "snakefiles" / "Pacbio"
     data = config.to_dict(args, readtype="pacbio")
     success = snakemake(
         snakefile,
@@ -58,7 +58,7 @@ def run_pacbio(args, config):
 
 
 def run_oxford(args, config):
-    snakefile = resource_filename("yeat", "workflows/snakefiles/Oxford")
+    snakefile = files("yeat") / "workflows" / "snakefiles" / "Oxford"
     data = config.to_dict(args, readtype="oxford")
     success = snakemake(
         snakefile,

--- a/yeat/workflows/bandage.py
+++ b/yeat/workflows/bandage.py
@@ -7,7 +7,7 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 from snakemake import snakemake
 import subprocess
 import warnings
@@ -29,7 +29,7 @@ def run_bandage(args, config):
     if not check_bandage():
         warnings.warn("Unable to run Bandage; skipping Bandage")
         return
-    snakefile = resource_filename("yeat", "workflows/snakefiles/Bandage")
+    snakefile = files("yeat") / "workflows" / "snakefiles" / "Bandage"
     data = config.to_dict(args)
     success = snakemake(
         snakefile, config=data, cores=args.threads, printshellcmds=True, workdir=args.outdir


### PR DESCRIPTION
This PR replaces the `pkg_resources` package with `importlib.resources` for getting the system path for installed files. This should eliminate some of the deprecation warnings emitted by the test suite at the moment.