### PR TITLE
Adding metaMDBG into YEAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Unicycler algorithm for long-read only assembly (#55)
+- metaMDBG algorithm for PacBio-HiFi reads (#)
 
 
 ## [0.4] 2023-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Unicycler algorithm for long-read only assembly (#55)
-- metaMDBG algorithm for PacBio-HiFi reads (#)
+- metaMDBG algorithm for PacBio-HiFi reads (#59)
 
 
 ## [0.4] 2023-08-23

--- a/Makefile
+++ b/Makefile
@@ -7,40 +7,48 @@ PYFILES = $(shell ls yeat/*.py yeat/*/*.py)
 help: Makefile
 	@sed -n 's/^## //p' Makefile
 
-## test:        run automated test suite
+## test:        run only short-running automated tests
 test:
-	pytest --cov=yeat -m 'not long and not bandage and not hifi and not nano'
+	pytest --cov=yeat -m short
 
 ## testlong:    run only long-running automated tests
 testlong:
-	pytest --cov=yeat -m 'long and not bandage and not hifi'
+	pytest --cov=yeat -m long
 
-## testbandage: run only bandage required automated tests
+## testillumina:run only Illumina short-read automated tests
+testillumina:
+	pytest --cov=yeat -m illumina
+
+## testhifi:    run only PacBio HiFi-read automated tests
+testhifi:
+	pytest --cov=yeat -m hifi
+
+## testnano:    run only Oxford Nanopore-read automated tests
+testnano:
+	pytest --cov=yeat -m nano
+
+## testbandage: run only Bandage required automated tests
 testbandage:
 	pytest --cov=yeat -m bandage
 
-## testhifi:    run only PacBio HiFi-reads automated tests
-testhifi:
-	pytest --cov=yeat -m 'hifi and not long and not bandage'
+## testlinux:   run only Linux required automated tests
+testlinux:
+	pytest --cov=yeat -m linux
 
-## testnano:    run only Oxford Nanopore-reads automated tests
-testnano:
-	pytest --cov=yeat -m 'nano and not long and not bandage'
-
-## testall:     run all tests but bandage required tests
+## testall:     run all tests but Bandage and linux required tests
 testall:
-	pytest --cov=yeat -m 'not bandage'
+	pytest --cov=yeat -m 'not bandage and not linux'
 
-## hifidata:    download PacBio HiFi test data for test suite
+## hifidata:    download PacBio HiFi-read test data for test suite
 hifidata:
 	curl -L -o yeat/tests/data/ecoli.fastq https://sra-pub-src-1.s3.amazonaws.com/SRR10971019/m54316_180808_005743.fastq.1
 	gzip yeat/tests/data/ecoli.fastq
 
-## nanodata:    download Oxford Nanopore test data for test suite
+## nanodata:    download Oxford Nanopore-read test data for test suite
 nanodata:
 	curl -L -o yeat/tests/data/ecolk12mg1655_R10_3_guppy_345_HAC.fastq.gz https://figshare.com/ndownloader/files/21623145
 
-## metadata:    download PacBio HiFi metagenomics test data for test suite
+## metadata:    download PacBio HiFi-read metagenomics test data for test suite
 metadata:
 	curl -L -o yeat/tests/data/zymoD6331std-ecoli-ten-percent.fq.gz https://zenodo.org/record/5908204/files/zymoD6331std-ecoli-ten-percent.fq.gz?download=1
 

--- a/README.md
+++ b/README.md
@@ -83,16 +83,16 @@ $ yeat --outdir {path} {config}
 
 ### Supported Input Reads with Assembly Algorithms
 
-| Readtype  | Algorithm |
+| Readtype  | Algorithms |
 | ------------- | ------------- |
 | paired  | spades, megahit, unicycler |
 | single  | spades, megahit, unicycler |
-| pacbio-raw  | flye, canu |
-| pacbio-corr  | flye, canu |
-| pacbio-hifi  | flye, canu, hifiasm, hifiasm-meta, metamdbg* |
-| nano-raw  | flye, canu |
-| nano-corr  | flye, canu |
-| nano-hq  | flye, canu |
+| pacbio-raw  | flye, canu, unicycler |
+| pacbio-corr  | flye, canu, unicycler |
+| pacbio-hifi  | flye, canu, hifiasm, hifiasm-meta, unicycler, metamdbg* |
+| nano-raw  | flye, canu, unicycler |
+| nano-corr  | flye, canu, unicycler |
+| nano-hq  | flye, canu, unicycler |
 
 \* \- Available on Linux OS only
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ yeat --outdir {path} {config}
 | nano-corr  | flye, canu |
 | nano-hq  | flye, canu |
 
-\* \- available on Linux OS only
+\* \- Available on Linux OS only
 
 
 ### Example config file

--- a/README.md
+++ b/README.md
@@ -20,15 +20,50 @@ Once the binary file has been obtained, users will need to update their environm
 
 Example for Ubuntu:
 ```
-export PATH={BANDAGE_DIR}:$PATH
+export PATH=~/projects/Bandage:$PATH
 ```
 
 Example for MacOS:
 ```
-export PATH={BANDAGE_DIR}/Bandage.app/Contents/MacOS:$PATH
+export PATH=~/projects/Bandage/Bandage.app/Contents/MacOS:$PATH
 ```
 
 In order to run the pre-built binary files successfully, ensure that the binary file is kept in the same directory with all of the other files that came with it.
+
+
+### Installing metaMDBG (for Linux OS only)
+
+To enable `metaMDBG` into YEAT's workflow, users will need to create a conda environment, install, and build from the source. Once created, YEAT will activate the environment whenever `metaMDBG` is called.
+
+#### Download metaMDBG repository  
+```
+git clone https://github.com/GaetanBenoitDev/metaMDBG.git
+```
+
+#### Create metaMDBG conda environment
+```
+cd metaMDBG
+conda env create -f conda_env.yml
+conda activate metaMDBG
+conda env config vars set CPATH=${CONDA_PREFIX}/include:${CPATH}
+conda deactivate
+
+# Activate metaMDBG environment
+conda activate metaMDBG
+
+# Compile the software
+mkdir build
+cd build
+cmake ..
+make -j 3
+```
+
+After successful installation, an executable named metaMDBG will appear in ./build/bin.
+
+#### Link the binary to the environment's bin
+```
+ln -s ~/projects/metaMDBG/build/bin/metaMDBG /home/danejo/anaconda3/envs/metaMDBG/bin/metaMDBG
+```
 
 ### Running PacBio Hifi and Nanopore-Reads Tests For Developers
 
@@ -54,10 +89,12 @@ $ yeat --outdir {path} {config}
 | single  | spades, megahit, unicycler |
 | pacbio-raw  | flye, canu |
 | pacbio-corr  | flye, canu |
-| pacbio-hifi  | flye, canu, hifiasm, hifiasm-meta |
+| pacbio-hifi  | flye, canu, hifiasm, hifiasm-meta, metamdbg* |
 | nano-raw  | flye, canu |
 | nano-corr  | flye, canu |
 | nano-hq  | flye, canu |
+
+\* \- available on Linux OS only
 
 
 ### Example config file

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,11 @@
 [pytest]
 markers =
+    short: short-running tests
+    long: long-running tests
+    illumina: illumina short-read tests
+    hifi: pacbio hifi-read tests
+    nano: oxford nanopore-read tests
     bandage: bandage required tests
-    long: long running tests
-    hifi: pacbio hifi-reads tests
-    nano: oxford nanopore-reads tests
+    linux: linux required test
 filterwarnings =
     ignore::DeprecationWarning:ratelimiter.*

--- a/yeat/cli/config.py
+++ b/yeat/cli/config.py
@@ -14,7 +14,7 @@ from warnings import warn
 
 PAIRED = ("spades", "megahit", "unicycler")
 SINGLE = ("spades", "megahit", "unicycler")
-PACBIO = ("canu", "flye", "hifiasm", "hifiasm-meta", "unicycler")
+PACBIO = ("canu", "flye", "hifiasm", "hifiasm-meta", "unicycler", "metamdbg")
 OXFORD = ("canu", "flye", "unicycler")
 ALGORITHMS = set(PAIRED + SINGLE + PACBIO + OXFORD)
 

--- a/yeat/tests/data/configs/meta.cfg
+++ b/yeat/tests/data/configs/meta.cfg
@@ -22,6 +22,14 @@
             "samples": [
                 "zymoBIOMICS_D6331"
             ]
+        },
+        {
+            "label": "metamdbg-default",
+            "algorithm": "metamdbg",
+            "extra_args": "",
+            "samples": [
+                "zymoBIOMICS_D6331"
+            ]
         }
     ]
 }

--- a/yeat/tests/test_bandage.py
+++ b/yeat/tests/test_bandage.py
@@ -30,6 +30,7 @@ def test_bandage_subprocess_failed(function_mock):
     assert bandage.check_bandage() == False
 
 
+@pytest.mark.short
 @patch.dict(os.environ, {"PATH": "ROUGE"})
 def test_env_path_has_no_path_to_bandage(capsys):
     bandage.check_bandage()
@@ -37,6 +38,7 @@ def test_env_path_has_no_path_to_bandage(capsys):
     assert "No such file or directory: 'Bandage'" in out
 
 
+@pytest.mark.short
 @patch("yeat.workflows.bandage.check_bandage")
 def test_no_bandage_warning(function_mock):
     function_mock.return_value = False
@@ -59,6 +61,7 @@ def test_assembly_graph_to_png(file, tmp_path):
     assert jpg.exists()
 
 
+@pytest.mark.short
 def test_convert_contig_to_fastg(tmp_path):
     contig = data_file("k29.contigs.fa.gz")
     fastg = tmp_path / "k29.contigs.fastg"

--- a/yeat/tests/test_cli.py
+++ b/yeat/tests/test_cli.py
@@ -14,6 +14,8 @@ from yeat import cli
 from yeat.cli import InitAction, illumina
 from yeat.tests import data_file
 
+pytestmark = pytest.mark.short
+
 
 def test_display_config_template(capsys):
     with pytest.raises(SystemExit):

--- a/yeat/tests/test_config.py
+++ b/yeat/tests/test_config.py
@@ -14,6 +14,8 @@ from yeat import cli
 from yeat.cli.config import Assembler, AssemblerConfig, AssemblyConfigurationError, Sample
 from yeat.tests import data_file
 
+pytestmark = pytest.mark.short
+
 
 def test_unsupported_assembly_algorithm():
     assembler = {

--- a/yeat/tests/test_config.py
+++ b/yeat/tests/test_config.py
@@ -10,6 +10,7 @@
 import json
 from pathlib import Path
 import pytest
+from unittest.mock import patch
 from yeat import cli
 from yeat.cli.config import Assembler, AssemblerConfig, AssemblyConfigurationError, Sample
 from yeat.tests import data_file
@@ -25,6 +26,19 @@ def test_unsupported_assembly_algorithm():
         "samples": ["sample1"],
     }
     pattern = rf"Unsupported assembly algorithm '{assembler['algorithm']}'"
+    with pytest.raises(ValueError, match=pattern):
+        Assembler(assembler, 1)
+
+
+@patch("yeat.cli.config.platform", "darwin")
+def test_linux_only_algorithm():
+    assembler = {
+        "label": "metamdbg-default",
+        "algorithm": "metamdbg",
+        "extra_args": "",
+        "samples": ["sample1"],
+    }
+    pattern = r"Assembly algorithm 'metaMDBG' can only run on Linux OS"
     with pytest.raises(ValueError, match=pattern):
         Assembler(assembler, 1)
 

--- a/yeat/tests/test_oxford.py
+++ b/yeat/tests/test_oxford.py
@@ -13,6 +13,7 @@ from yeat import cli
 from yeat.tests import data_file, get_core_count, write_config, files_exist
 
 
+@pytest.mark.short
 def test_oxford_nanopore_assemblers_dry_run(tmp_path):
     wd = str(tmp_path)
     arglist = ["-o", wd, "-n", "-t", "4", data_file("configs/ont.cfg")]
@@ -20,6 +21,7 @@ def test_oxford_nanopore_assemblers_dry_run(tmp_path):
     cli.main(args)
 
 
+@pytest.mark.long
 @pytest.mark.nano
 @pytest.mark.parametrize(
     "labels,expected",

--- a/yeat/tests/test_pacbio.py
+++ b/yeat/tests/test_pacbio.py
@@ -13,6 +13,7 @@ from yeat import cli
 from yeat.tests import data_file, get_core_count, write_config, files_exist
 
 
+@pytest.mark.short
 def test_pacbio_hifi_assemblers_dry_run(tmp_path):
     wd = str(tmp_path)
     arglist = ["-o", wd, "-n", "-t", "4", data_file("configs/hifi.cfg")]
@@ -20,6 +21,7 @@ def test_pacbio_hifi_assemblers_dry_run(tmp_path):
     cli.main(args)
 
 
+@pytest.mark.long
 @pytest.mark.hifi
 @pytest.mark.parametrize(
     "labels,expected",
@@ -41,6 +43,7 @@ def test_pacbio_hifi_read_assemblers(labels, expected, capsys, tmp_path):
     files_exist(wd, assemblers, expected)
 
 
+@pytest.mark.long
 @pytest.mark.hifi
 @pytest.mark.parametrize(
     "labels,expected",
@@ -60,6 +63,13 @@ def test_pacbio_hifi_read_metagenomic_assemblers(labels, expected, capsys, tmp_p
     files_exist(wd, assemblers, expected)
 
 
-
-def test_metaMDBG_assembler():
-    pass
+@pytest.mark.linux
+def test_metaMDBG_assembler(tmp_path):
+    wd = str(tmp_path)
+    assemblers = write_config(["metamdbg-default"], wd, "meta.cfg")
+    cores = str(get_core_count())
+    cfg = str(Path(wd) / "meta.cfg")
+    arglist = ["-o", wd, "-t", cores, cfg]
+    args = cli.get_parser().parse_args(arglist)
+    cli.main(args)
+    files_exist(wd, assemblers, "contigs.fasta")

--- a/yeat/tests/test_pacbio.py
+++ b/yeat/tests/test_pacbio.py
@@ -58,3 +58,8 @@ def test_pacbio_hifi_read_metagenomic_assemblers(labels, expected, capsys, tmp_p
     args = cli.get_parser().parse_args(arglist)
     cli.main(args)
     files_exist(wd, assemblers, expected)
+
+
+
+def test_metaMDBG_assembler():
+    pass

--- a/yeat/tests/test_paired.py
+++ b/yeat/tests/test_paired.py
@@ -17,6 +17,7 @@ from yeat import cli
 from yeat.tests import data_file, write_config, files_exist
 
 
+@pytest.mark.short
 def test_paired_end_assemblers_dry_run(tmp_path):
     wd = str(tmp_path)
     arglist = ["-o", wd, "-n", data_file("configs/paired.cfg")]
@@ -25,6 +26,7 @@ def test_paired_end_assemblers_dry_run(tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 @pytest.mark.parametrize(
     "labels,expected",
     [
@@ -44,6 +46,7 @@ def test_paired_end_assemblers(labels, expected, capsys, tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 def test_multiple_paired_end_assemblers(capsys, tmp_path):
     wd = str(tmp_path)
     arglist = ["-o", wd, data_file(f"configs/paired.cfg")]
@@ -60,6 +63,7 @@ def test_multiple_paired_end_assemblers(capsys, tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 def test_multiple_spades(capsys, tmp_path):
     wd = str(tmp_path)
     arglist = ["-o", wd, data_file(f"configs/two_spades.cfg")]
@@ -71,6 +75,7 @@ def test_multiple_spades(capsys, tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 @pytest.mark.parametrize(
     "downsample,num_contigs,largest_contig,total_len",
     [("2000", 79, 5294, 70818), ("-1", 56, 35168, 199940)],
@@ -91,6 +96,7 @@ def test_custom_downsample_input(
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 @pytest.mark.parametrize("coverage", [("150"), ("75"), ("10")])
 def test_custom_coverage_input(coverage, capsys, tmp_path):
     wd = str(tmp_path)
@@ -109,6 +115,7 @@ def test_custom_coverage_input(coverage, capsys, tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 @pytest.mark.parametrize("execution_number", range(3))
 def test_random_downsample_seed(execution_number, capsys, tmp_path):
     wd = str(tmp_path)
@@ -139,6 +146,7 @@ def prep_uncompressed_reads(filename, tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 @pytest.mark.parametrize(
     "inread1,inread2",
     [

--- a/yeat/tests/test_single.py
+++ b/yeat/tests/test_single.py
@@ -13,6 +13,7 @@ from yeat import cli
 from yeat.tests import data_file, write_config, files_exist
 
 
+@pytest.mark.short
 def test_single_end_assemblers_dry_run(tmp_path):
     wd = str(tmp_path)
     arglist = ["-o", wd, "-n", data_file("configs/single.cfg")]
@@ -21,6 +22,7 @@ def test_single_end_assemblers_dry_run(tmp_path):
 
 
 @pytest.mark.long
+@pytest.mark.illumina
 @pytest.mark.parametrize(
     "labels,expected",
     [

--- a/yeat/workflows/__init__.py
+++ b/yeat/workflows/__init__.py
@@ -52,6 +52,7 @@ def run_pacbio(args, config):
         dryrun=args.dry_run,
         printshellcmds=True,
         workdir=args.outdir,
+        use_conda=True,
     )
     if not success:
         raise RuntimeError("Snakemake Failed")  # pragma: no cover

--- a/yeat/workflows/snakefiles/Bandage
+++ b/yeat/workflows/snakefiles/Bandage
@@ -137,3 +137,17 @@ rule hifiasm_meta:
             filename = Path(gfa).stem
             shell("Bandage image {gfa} {params.outdir}/{filename}.jpg")
         shell("touch {output.status}")
+
+
+rule metamdbg:
+    output:
+        status="analysis/{sample}/{label}/metamdbg/bandage/.done"
+    input:
+        gfa="analysis/{sample}/{label}/metamdbg/tmp/assembly_graph.gfa"
+    params:
+        outdir=lambda wildcards: f"analysis/{wildcards.sample}/{wildcards.label}/metamdbg/bandage"
+    shell:
+        """
+        Bandage image {input.gfa} {params.outdir}/assembly_graph.jpg
+        touch {output.status}
+        """

--- a/yeat/workflows/snakefiles/Pacbio
+++ b/yeat/workflows/snakefiles/Pacbio
@@ -136,7 +136,7 @@ rule metamdbg:
     threads: 128
     params:
         outdir=lambda wildcards: f"analysis/{wildcards.sample}/{wildcards.label}/metamdbg",
-        extra_args=lambda wildcards: config["extra_args"][wildcards.label]
+        extra_args=lambda wildcards: config["extra_args"][wildcards.label] #add extra_args....
     shell:
         """
         metaMDBG asm {params.outdir} {input.reads} -t {threads}

--- a/yeat/workflows/snakefiles/Pacbio
+++ b/yeat/workflows/snakefiles/Pacbio
@@ -136,10 +136,10 @@ rule metamdbg:
     threads: 128
     params:
         outdir=lambda wildcards: f"analysis/{wildcards.sample}/{wildcards.label}/metamdbg",
-        extra_args=lambda wildcards: config["extra_args"][wildcards.label] #add extra_args....
+        extra_args=lambda wildcards: config["extra_args"][wildcards.label]
     shell:
         """
-        metaMDBG asm {params.outdir} {input.reads} -t {threads}
+        metaMDBG asm {params.outdir} {input.reads} -t {threads} {params.extra_args}
         gunzip {params.outdir}/contigs.fasta.gz
         ln -s contigs.fasta {output.contigs}
         """

--- a/yeat/workflows/snakefiles/Pacbio
+++ b/yeat/workflows/snakefiles/Pacbio
@@ -124,3 +124,22 @@ rule unicycler:
         unicycler -l {input.reads} -t {threads} -o {params.outdir} {params.extra_args}
         ln -s assembly.fasta {output.contigs}
         """
+
+
+rule metamdbg:
+    output:
+        contigs="analysis/{sample}/{label}/metamdbg/{sample}_contigs.fasta"
+    input:
+        reads="seq/input/{sample}/combined-reads.fq.gz"
+    conda:
+        "metaMDBG"
+    threads: 128
+    params:
+        outdir=lambda wildcards: f"analysis/{wildcards.sample}/{wildcards.label}/metamdbg",
+        extra_args=lambda wildcards: config["extra_args"][wildcards.label]
+    shell:
+        """
+        metaMDBG asm {params.outdir} {input.reads} -t {threads}
+        gunzip {params.outdir}/contigs.fasta.gz
+        ln -s contigs.fasta {output.contigs}
+        """


### PR DESCRIPTION
The purpose of this PR is to resolve #57 .

In this PR, the assembly algorithm `metaMDBG` was added into YEAT's workflow; however, this algorithm is only available for Linux OS users. If the user tries to include `metaMDBG` in their config file and their system is not a linux OS, YEAT will stop and notify users to look at their config file.

In addition to adding `metaMDBG` into the workflow, I have spent sometime cleaning up the `makefile` and pytests.