### PR TITLE
Updating the test suite to reflect how Assembly objects are created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Hybrid assembly support (#68)
+- Hybrid assembly support (#68, #70)
 
 
 ## [0.5] 2024-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Hybrid assembly support (#68, #70)
+- Hybrid assembly support (#68, #73)
 
 
 ## [0.5] 2024-01-08

--- a/yeat/config/assembly.py
+++ b/yeat/config/assembly.py
@@ -80,7 +80,7 @@ class Assembly:
             return sample.long_readtype in OXFORD_READS
         elif self.mode == "hybrid":
             return sample.short_readtype == "paired" and sample.long_readtype in LONG_READS
-        else:
+        else:  # pragma: no cover
             message = f"Invalid assembly mode '{self.mode}'"
             raise AssemblyConfigError(message)
 
@@ -102,6 +102,6 @@ class Assembly:
             return self.mode
         elif self.mode in ["pacbio", "oxford"]:
             return sample.long_readtype
-        else:
+        else:  # pragma: no cover
             message = f"Invalid assembly mode '{self.mode}'"
             raise AssemblyConfigError(message)

--- a/yeat/config/sample.py
+++ b/yeat/config/sample.py
@@ -113,6 +113,6 @@ class Sample:
                 f"seq/nanoplot/{self.label}/{readtype}/{quality}_LengthvsQualityScatterPlot_dot.pdf"
                 for quality in ["raw", "filtered"]
             ]
-        else:
+        else:  # pragma: no cover
             message = f"Invalid readtype '{readtype}'"
             raise AssemblyConfigError(message)

--- a/yeat/tests/test_config.py
+++ b/yeat/tests/test_config.py
@@ -20,29 +20,33 @@ pytestmark = pytest.mark.short
 
 
 def test_invalid_assembly_algorithm():
-    label = "label1"
-    data = {
+    config_data = json.load(open(data_file("configs/example.cfg")))
+    samples = {"sample1": Sample("sample1", config_data["samples"]["sample1"])}
+    assembly_label = "label1"
+    assembly_data = {
         "algorithm": "INVALID",
         "extra_args": "",
-        "samples": ["sample1"],
+        "samples": samples,
         "mode": "paired",
     }
-    pattern = rf"Invalid assembly algorithm '{data['algorithm']}' for '{label}'"
+    pattern = rf"Invalid assembly algorithm '{assembly_data['algorithm']}' for '{assembly_label}'"
     with pytest.raises(ValueError, match=pattern):
-        Assembly(label, data)
+        Assembly(assembly_label, assembly_data)
 
 
 @patch("yeat.config.assembly.platform", "darwin")
 def test_linux_only_algorithm():
-    data = {
+    config_data = json.load(open(data_file("configs/example.cfg")))
+    samples = {"sample3", Sample("sample3", config_data["samples"]["sample3"])}
+    assembly_data = {
         "algorithm": "metamdbg",
         "extra_args": "",
-        "samples": ["sample1"],
+        "samples": samples,
         "mode": "pacbio",
     }
     pattern = r"Assembly algorithm 'metaMDBG' can only run on 'Linux OS'"
     with pytest.raises(ValueError, match=pattern):
-        Assembly("label1", data)
+        Assembly("label1", assembly_data)
 
 
 def test_valid_config():
@@ -97,27 +101,31 @@ def test_sample_with_duplicate_reads():
     ],
 )
 def test_check_canu_required_params_errors(extra_args, cores, expected):
-    data = {
+    config_data = json.load(open(data_file("configs/example.cfg")))
+    samples = {"sample3": Sample("sample3", config_data["samples"]["sample3"])}
+    assembly_data = {
         "algorithm": "canu",
         "extra_args": extra_args,
-        "samples": ["sample1"],
+        "samples": samples,
         "mode": "pacbio",
     }
     with pytest.raises(ValueError, match=expected):
-        Assembly("label1", data, cores)
+        Assembly("label1", assembly_data, cores)
 
 
 def test_check_valid_mode():
-    label = "label1"
-    data = {
+    config_data = json.load(open(data_file("configs/example.cfg")))
+    samples = {"sample1": Sample("sample1", config_data["samples"]["sample1"])}
+    assembly_label = "label1"
+    assembly_data = {
         "algorithm": "spades",
         "extra_args": "",
-        "samples": ["sample1"],
+        "samples": samples,
         "mode": "INVALID",
     }
-    pattern = rf"Invalid assembly mode '{data['mode']}' for '{label}'"
+    pattern = rf"Invalid assembly mode '{assembly_data['mode']}' for '{assembly_label}'"
     with pytest.raises(AssemblyConfigError, match=pattern):
-        Assembly(label, data)
+        Assembly(assembly_label, assembly_data)
 
 
 @pytest.mark.parametrize("layer", ["base", "sample", "assembly"])

--- a/yeat/workflow/aux.py
+++ b/yeat/workflow/aux.py
@@ -30,7 +30,7 @@ def get_canu_readtype_flag(readtype):
         return "-pacbio"
     elif readtype == "pacbio-hifi":
         return "-pacbio-hifi"
-    else:
+    else:  # pragma: no cover
         message = f"Invalid readtype '{readtype}'"
         raise ValueError()
 
@@ -89,6 +89,6 @@ def get_longread_file(sample, long_readtype):
         return f"seq/input/{sample}/{long_readtype}/combined-reads.fq.gz"
     elif long_readtype in OXFORD_READS:
         return f"seq/nanofilt/{sample}/{long_readtype}/highQuality-reads.fq.gz"
-    else:
+    else:  # pragma: no cover
         message = f"Invalid long readtype '{long_readtype}'"
         raise ValueError(message)


### PR DESCRIPTION
In this PR, #68, Assembly object requires a dictionary of samples objects instead of lists. This PR updates the test suite to reflect that change.