### PR TITLE
`yeat-auto` - automatically fill in samples for the config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Hybrid assembly support (#68, #73)
 - `just-yeat-it` CLI command for simple paired-end runs (#74)
-- `yeat-auto` CLI command for auto-populating the sample section of the config file (#)
+- `yeat-auto` CLI command for auto-populating the sample section of the config file (#76)
 
 
 ## [0.5] 2024-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Hybrid assembly support (#68, #73)
 - `just-yeat-it` CLI command for simple paired-end runs (#74)
+- `yeat-auto` CLI command for auto-populating the sample section of the config file (#)
 
 
 ## [0.5] 2024-01-08

--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ To run a simple paired-end assembly, use the `just-yeat-it` command. Otherwise, 
 $ just-yeat-it --outdir {path} {read1} {read2}
 ```
 
+Auto-populate config file with a directory of paired-end reads.
+```
+$ yeat-auto short_reads --seq-path data/ -o config.cfg
+```
+
+Auto-populate config file with a list of paired-end read files.
+```
+$ yeat-auto short_reads --files short_reads_1.fastq.gz short_reads_2.fastq.gz -o config.cfg
+```
+
 ### Supported Input Reads with Assembly Algorithms
 
 | Readtype  | Algorithms |

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     entry_points={
         'console_scripts': [
             'yeat=yeat.cli:main',
-            'just-yeat-it=yeat.cli.just_yeat_it:main'
+            'just-yeat-it=yeat.cli.just_yeat_it:main',
+            'yeat-auto=yeat.cli.yeat_auto:main'
         ],
     },
     classifiers=[

--- a/yeat/cli/auto_pop.py
+++ b/yeat/cli/auto_pop.py
@@ -23,6 +23,7 @@ class AutoPop:
     def __init__(self, args):
         self.samples = self.get_samples(args.samples)
         self.check_samples()
+        self.check_seq_path(args.seq_path)
         self.files = self.get_files(args.files, args.seq_path)
         self.check_files()
         self.files_to_samples = self.organize_files_to_samples()
@@ -44,6 +45,13 @@ class AutoPop:
                     message = f"cannot correctly process a sample name that is a substring of another sample name: {s1} vs. {s2}"
                     raise AutoPopError(message)
 
+    def check_seq_path(self, seq_path):
+        if not seq_path:
+            return
+        if not Path(seq_path).exists():
+            message = f"path does not exist: '{seq_path}'"
+            raise AutoPopError(message)
+
     def get_files(self, files, seq_path):
         if files:
             return [Path(f) for f in files]
@@ -55,7 +63,6 @@ class AutoPop:
         return files
 
     def check_files(self):
-        print(self.files)
         for file in self.files:
             if not file.exists():
                 message = f"file does not exist: {file}"
@@ -64,7 +71,7 @@ class AutoPop:
     def traverse(self, dirpath):
         dirpath = Path(dirpath)
         if not dirpath.is_dir():
-            return
+            return  # pragma: no cover
         for subpath in dirpath.iterdir():
             if subpath.is_dir():
                 yield from self.traverse(subpath)

--- a/yeat/cli/auto_pop.py
+++ b/yeat/cli/auto_pop.py
@@ -78,11 +78,22 @@ class AutoPop:
                 raise AutoPopError(message)
 
     def write_config_file(self, outfile):
-        samples = {}
-        for label, reads in self.files_to_samples.items():
-            samples[label] = {"paired": [reads]}
-        data = {"samples": samples, "assemblies": {}}
+        data = self.get_config_data()
         outdir = Path(outfile).parent
         outdir.mkdir(parents=True, exist_ok=True)
         outfile = open(outfile, "w")
         json.dump(data, outfile, indent=4)
+
+    def get_config_data(self):
+        samples = {}
+        for label, reads in self.files_to_samples.items():
+            samples[label] = {"paired": [reads]}
+        assemblies = {
+            "spades-default": {
+                "algorithm": "spades",
+                "extra_args": "",
+                "samples": self.samples,
+                "mode": "paired",
+            }
+        }
+        return {"samples": samples, "assemblies": assemblies}

--- a/yeat/cli/auto_pop.py
+++ b/yeat/cli/auto_pop.py
@@ -41,7 +41,7 @@ class AutoPop:
                     continue
                 if s1 in s2:
                     message = f"cannot correctly process a sample name that is a substring of another sample name: {s1} vs. {s2}"
-                    raise ValueError(message)
+                    raise AutoPopError(message)
 
     def get_files(self, files, seq_path):
         if files:
@@ -82,7 +82,7 @@ class AutoPop:
         for label, reads in self.files_to_samples.items():
             samples[label] = {"paired": [reads]}
         data = {"samples": samples, "assemblies": {}}
-        outdir = Path(outfile).parent.absolute()
+        outdir = Path(outfile).parent
         outdir.mkdir(parents=True, exist_ok=True)
         outfile = open(outfile, "w")
         json.dump(data, outfile, indent=4)

--- a/yeat/cli/auto_pop.py
+++ b/yeat/cli/auto_pop.py
@@ -1,0 +1,88 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2024, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+from collections import defaultdict
+import json
+from pathlib import Path
+
+
+EXTENSIONS = (".fastq", ".fastq.gz", ".fq", ".fq.gz")
+
+
+class AutoPopError(ValueError):
+    pass
+
+
+class AutoPop:
+    def __init__(self, args):
+        self.samples = self.get_samples(args.samples)
+        self.check_samples()
+        self.files = self.get_files(args.files, args.seq_path)
+        self.files_to_samples = self.organize_files_to_samples()
+        self.check_files_to_samples()
+        self.write_config_file(args.outfile)
+
+    def get_samples(self, samples):
+        if len(samples) == 1 and Path(samples[0]).is_file():
+            with open(samples[0], "r") as fh:
+                samples = fh.read().strip().split("\n")
+        return list(sorted(samples))
+
+    def check_samples(self):
+        for s1_index, s1 in enumerate(self.samples):
+            for s2_index, s2 in enumerate(self.samples):
+                if s1 == s2 and s1_index == s2_index:
+                    continue
+                if s1 in s2:
+                    message = f"cannot correctly process a sample name that is a substring of another sample name: {s1} vs. {s2}"
+                    raise ValueError(message)
+
+    def get_files(self, files, seq_path):
+        if files:
+            return files
+        files = []
+        for file in self.traverse(seq_path):
+            if not file.name.endswith(EXTENSIONS):
+                continue
+            files.append(file)
+        return files
+
+    def traverse(self, dirpath):
+        dirpath = Path(dirpath)
+        if not dirpath.is_dir():
+            return
+        for subpath in dirpath.iterdir():
+            if subpath.is_dir():
+                yield from self.traverse(subpath)
+            else:
+                yield subpath
+
+    def organize_files_to_samples(self):
+        files_to_samples = defaultdict(list)
+        for sample in self.samples:
+            files_to_samples[sample] = [
+                str(file.absolute()) for file in self.files if sample in str(file)
+            ]
+        return files_to_samples
+
+    def check_files_to_samples(self):
+        for sample, files in self.files_to_samples.items():
+            if len(files) != 2:
+                message = f"sample {sample}: expected 2 FASTQ files for paired-end data, found {len(files)}"
+                raise AutoPopError(message)
+
+    def write_config_file(self, outfile):
+        samples = {}
+        for label, reads in self.files_to_samples.items():
+            samples[label] = {"paired": [reads]}
+        data = {"samples": samples, "assemblies": {}}
+        outdir = Path(outfile).parent.absolute()
+        outdir.mkdir(parents=True, exist_ok=True)
+        outfile = open(outfile, "w")
+        json.dump(data, outfile, indent=4)

--- a/yeat/cli/yeat_auto.py
+++ b/yeat/cli/yeat_auto.py
@@ -15,7 +15,7 @@ def main(args=None):
     if args is None:
         args = get_parser().parse_args()  # pragma: no cover
     autopop = AutoPop(args.samples, args.seq_path, args.files)
-    autopop.write_config_file(args.outfile)
+    autopop.write_config_file()
 
 
 def get_parser(exit_on_error=True):
@@ -40,14 +40,6 @@ def options(parser):
         help="a list of FASTQ files to use as input; incompatible with --seq-path",
         metavar="FQ",
         nargs="+",
-    )
-    parser.add_argument(
-        "-o",
-        "--outfile",
-        default="config.cfg",
-        help='output config file; by default, "config.cfg"',
-        metavar="FILE",
-        type=str,
     )
 
 

--- a/yeat/cli/yeat_auto.py
+++ b/yeat/cli/yeat_auto.py
@@ -43,16 +43,16 @@ def input_configuration(parser):
     meg = ingrp.add_mutually_exclusive_group()
     meg.add_argument(
         "--seq-path",
-        metavar="PATH",
         default=None,
         help="path to a directory containing FASTQ files to use as input; incompatible with --files",
+        metavar="PATH",
     )
     meg.add_argument(
         "--files",
-        metavar="FQ",
-        nargs="+",
         default=None,
         help="a list of FASTQ files to use as input; incompatible with --seq-path",
+        metavar="FQ",
+        nargs="+",
     )
 
 
@@ -60,6 +60,6 @@ def positional_args(parser):
     parser._positionals.title = "required arguments"
     parser.add_argument(
         "samples",
-        nargs="+",
         help="list of sample names or path to .txt file containing sample names",
+        nargs="+",
     )

--- a/yeat/cli/yeat_auto.py
+++ b/yeat/cli/yeat_auto.py
@@ -7,40 +7,27 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
-from .auto_pop import AutoPop
 from argparse import ArgumentParser
+from yeat.config.auto_pop import AutoPop
 
 
 def main(args=None):
     if args is None:
         args = get_parser().parse_args()  # pragma: no cover
-    AutoPop(args)
+    autopop = AutoPop(args.samples, args.seq_path, args.files)
+    autopop.write_config_file(args.outfile)
 
 
 def get_parser(exit_on_error=True):
     parser = ArgumentParser(exit_on_error=exit_on_error)
-    parser._optionals.title = "options"
-    config_configuration(parser)
-    input_configuration(parser)
+    options(parser)
     positional_args(parser)
     return parser
 
 
-def config_configuration(parser):
-    config = parser.add_argument_group("config configuration")
-    config.add_argument(
-        "-o",
-        "--outfile",
-        default="config.cfg",
-        help='output config file; by default, "config.cfg"',
-        metavar="FILE",
-        type=str,
-    )
-
-
-def input_configuration(parser):
-    ingrp = parser.add_argument_group("input configuration")
-    meg = ingrp.add_mutually_exclusive_group(required=True)
+def options(parser):
+    parser._optionals.title = "options"
+    meg = parser.add_mutually_exclusive_group(required=True)
     meg.add_argument(
         "--seq-path",
         default=None,
@@ -53,6 +40,14 @@ def input_configuration(parser):
         help="a list of FASTQ files to use as input; incompatible with --seq-path",
         metavar="FQ",
         nargs="+",
+    )
+    parser.add_argument(
+        "-o",
+        "--outfile",
+        default="config.cfg",
+        help='output config file; by default, "config.cfg"',
+        metavar="FILE",
+        type=str,
     )
 
 

--- a/yeat/cli/yeat_auto.py
+++ b/yeat/cli/yeat_auto.py
@@ -40,7 +40,7 @@ def config_configuration(parser):
 
 def input_configuration(parser):
     ingrp = parser.add_argument_group("input configuration")
-    meg = ingrp.add_mutually_exclusive_group()
+    meg = ingrp.add_mutually_exclusive_group(required=True)
     meg.add_argument(
         "--seq-path",
         default=None,

--- a/yeat/cli/yeat_auto.py
+++ b/yeat/cli/yeat_auto.py
@@ -1,0 +1,65 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2024, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+from .auto_pop import AutoPop
+from argparse import ArgumentParser
+
+
+def main(args=None):
+    if args is None:
+        args = get_parser().parse_args()  # pragma: no cover
+    AutoPop(args)
+
+
+def get_parser(exit_on_error=True):
+    parser = ArgumentParser(exit_on_error=exit_on_error)
+    parser._optionals.title = "options"
+    config_configuration(parser)
+    input_configuration(parser)
+    positional_args(parser)
+    return parser
+
+
+def config_configuration(parser):
+    config = parser.add_argument_group("config configuration")
+    config.add_argument(
+        "-o",
+        "--outfile",
+        default="config.cfg",
+        help='output config file; by default, "config.cfg"',
+        metavar="FILE",
+        type=str,
+    )
+
+
+def input_configuration(parser):
+    ingrp = parser.add_argument_group("input configuration")
+    meg = ingrp.add_mutually_exclusive_group()
+    meg.add_argument(
+        "--seq-path",
+        metavar="PATH",
+        default=None,
+        help="path to a directory containing FASTQ files to use as input; incompatible with --files",
+    )
+    meg.add_argument(
+        "--files",
+        metavar="FQ",
+        nargs="+",
+        default=None,
+        help="a list of FASTQ files to use as input; incompatible with --seq-path",
+    )
+
+
+def positional_args(parser):
+    parser._positionals.title = "required arguments"
+    parser.add_argument(
+        "samples",
+        nargs="+",
+        help="list of sample names or path to .txt file containing sample names",
+    )

--- a/yeat/config/auto_pop.py
+++ b/yeat/config/auto_pop.py
@@ -7,7 +7,6 @@
 # Development Center.
 # -------------------------------------------------------------------------------------------------
 
-from collections import defaultdict
 import json
 from pathlib import Path
 
@@ -48,8 +47,7 @@ class AutoPop:
         if not seq_path:
             return
         if not Path(seq_path).exists():
-            message = f"path does not exist: '{seq_path}'"
-            raise AutoPopError(message)
+            raise FileNotFoundError(seq_path)
 
     def get_files(self, seq_path):
         files = []
@@ -72,11 +70,10 @@ class AutoPop:
     def check_files(self):
         for file in self.files:
             if not file.exists():
-                message = f"file does not exist: {file}"
-                raise AutoPopError(message)
+                raise FileNotFoundError(file)
 
     def organize_files_to_samples(self):
-        files_to_samples = defaultdict(list)
+        files_to_samples = dict()
         for sample in self.samples:
             files_to_samples[sample] = [file for file in self.files if sample in str(file)]
         return files_to_samples
@@ -87,12 +84,9 @@ class AutoPop:
                 message = f"sample {sample}: expected 2 FASTQ files for paired-end data, found {len(files)}"
                 raise AutoPopError(message)
 
-    def write_config_file(self, outfile):
+    def write_config_file(self):
         data = self.get_config_data()
-        outdir = Path(outfile).parent
-        outdir.mkdir(parents=True, exist_ok=True)
-        outfile = open(outfile, "w")
-        json.dump(data, outfile, indent=4)
+        print(json.dumps(data, indent=4))
 
     def get_config_data(self):
         samples = {}

--- a/yeat/tests/data/configs/auto_one_sample.cfg
+++ b/yeat/tests/data/configs/auto_one_sample.cfg
@@ -1,0 +1,22 @@
+{
+    "samples": {
+        "short_reads": {
+            "paired": [
+                [
+                    "/Users/dane.jo/Desktop/yeattest/data/short_reads_1.fastq.gz",
+                    "/Users/dane.jo/Desktop/yeattest/data/short_reads_2.fastq.gz"
+                ]
+            ]
+        }
+    },
+    "assemblies": {
+        "spades-default": {
+            "algorithm": "spades",
+            "extra_args": "",
+            "samples": [
+                "short_reads"
+            ],
+            "mode": "paired"
+        }
+    }
+}

--- a/yeat/tests/data/configs/auto_two_samples.cfg
+++ b/yeat/tests/data/configs/auto_two_samples.cfg
@@ -1,5 +1,13 @@
 {
     "samples": {
+        "Animal_289": {
+            "paired": [
+                [
+                    "yeat/tests/data/Animal_289_R1.fq.gz",
+                    "yeat/tests/data/Animal_289_R2.fq.gz"
+                ]
+            ]
+        },
         "short_reads": {
             "paired": [
                 [
@@ -14,6 +22,7 @@
             "algorithm": "spades",
             "extra_args": "",
             "samples": [
+                "Animal_289",
                 "short_reads"
             ],
             "mode": "paired"

--- a/yeat/tests/data/one_sample.txt
+++ b/yeat/tests/data/one_sample.txt
@@ -1,0 +1,1 @@
+short_reads

--- a/yeat/tests/data/two_samples.txt
+++ b/yeat/tests/data/two_samples.txt
@@ -1,0 +1,2 @@
+short_reads
+Animal_289

--- a/yeat/tests/test_yeat_auto.py
+++ b/yeat/tests/test_yeat_auto.py
@@ -1,0 +1,46 @@
+# -------------------------------------------------------------------------------------------------
+# Copyright (c) 2024, DHS. This file is part of YEAT: http://github.com/bioforensics/yeat
+#
+# This software was prepared for the Department of Homeland Security (DHS) by the Battelle National
+# Biodefense Institute, LLC (BNBI) as part of contract HSHQDC-15-C-00064 to manage and operate the
+# National Biodefense Analysis and Countermeasures Center (NBACC), a Federally Funded Research and
+# Development Center.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+from yeat.cli.yeat_auto import get_parser, main
+from yeat.tests import data_file
+
+
+def run_yeat_auto(arglist):
+    args = get_parser().parse_args(arglist)
+    main(args)
+
+
+@pytest.mark.short
+def test_yeat_auto(tmp_path):
+    wd = str(tmp_path)
+    arglist = [
+        "short_reads",
+        "--files",
+        data_file("short_reads_1.fastq.gz"),
+        data_file("short_reads_2.fastq.gz"),
+        "-o",
+        f"{wd}/config.cfg",
+    ]
+    run_yeat_auto(arglist)
+    print(wd)
+    assert 0
+
+
+# test one sample
+# test two samples
+# test sample.txt
+# test --seq-path bad path
+# test --seq-path no path
+# test --seq-path good
+# test --files no files
+# test --files one file
+# test --files bad first file
+# test --files bad second file
+# test --files good

--- a/yeat/tests/test_yeat_auto.py
+++ b/yeat/tests/test_yeat_auto.py
@@ -8,8 +8,17 @@
 # -------------------------------------------------------------------------------------------------
 
 import pytest
+import re
+from yeat.cli.auto_pop import AutoPopError
 from yeat.cli.yeat_auto import get_parser, main
 from yeat.tests import data_file
+
+pytestmark = pytest.mark.short
+
+
+SHORT_READS = [data_file("short_reads_1.fastq.gz"), data_file("short_reads_2.fastq.gz")]
+ANIMAL_READS = [data_file("Animal_289_R1.fq.gz"), data_file("Animal_289_R2.fq.gz")]
+ALL_READS = SHORT_READS + ANIMAL_READS
 
 
 def run_yeat_auto(arglist):
@@ -17,30 +26,99 @@ def run_yeat_auto(arglist):
     main(args)
 
 
-@pytest.mark.short
-def test_yeat_auto(tmp_path):
+def compare_config_data(observed, expected):
+    with open(observed, "r") as f:
+        observed_data = f.read().strip()
+    with open(expected, "r") as f:
+        expected_data = f.read().strip()
+    expected_data = re.sub(r"yeat\/tests\/data", f'{data_file("")}', expected_data)
+    assert observed_data == expected_data
+
+
+@pytest.mark.parametrize(
+    "sequences,expected",
+    [
+        (["short_reads"], data_file("configs/auto_one_sample.cfg")),
+        (["short_reads", "Animal_289"], data_file("configs/auto_two_samples.cfg")),
+        ([data_file("one_sample.txt")], data_file("configs/auto_one_sample.cfg")),
+        ([data_file("two_samples.txt")], data_file("configs/auto_two_samples.cfg")),
+    ],
+)
+def test_yeat_auto_with_seq_path(sequences, expected, tmp_path):
     wd = str(tmp_path)
-    arglist = [
-        "short_reads",
-        "--files",
-        data_file("short_reads_1.fastq.gz"),
-        data_file("short_reads_2.fastq.gz"),
-        "-o",
-        f"{wd}/config.cfg",
-    ]
+    config = f"{wd}/config.cfg"
+    arglist = sequences + ["-o", config, "--seq-path", data_file("")]
     run_yeat_auto(arglist)
-    print(wd)
-    assert 0
+    compare_config_data(config, expected)
 
 
-# test one sample
-# test two samples
-# test sample.txt
-# test --seq-path bad path
-# test --seq-path no path
-# test --seq-path good
-# test --files no files
-# test --files one file
-# test --files bad first file
-# test --files bad second file
-# test --files good
+def test_bad_input_seq_path(tmp_path):
+    wd = str(tmp_path)
+    config = f"{wd}/config.cfg"
+    arglist = ["short_reads", "-o", config, "--seq-path", "DNE"]
+    with pytest.raises(AutoPopError, match="path does not exist: 'DNE'"):
+        run_yeat_auto(arglist)
+
+
+def test_sequence_with_no_files(tmp_path):
+    wd = str(tmp_path)
+    config = f"{wd}/config.cfg"
+    arglist = ["SAMPLE", "-o", config, "--seq-path", data_file("")]
+    message = "sample SAMPLE: expected 2 FASTQ files for paired-end data, found 0"
+    with pytest.raises(AutoPopError, match=message):
+        run_yeat_auto(arglist)
+
+
+@pytest.mark.parametrize(
+    "sequences,files,expected",
+    [
+        (["short_reads"], SHORT_READS, data_file("configs/auto_one_sample.cfg")),
+        (["short_reads", "Animal_289"], ALL_READS, data_file("configs/auto_two_samples.cfg")),
+        ([data_file("one_sample.txt")], SHORT_READS, data_file("configs/auto_one_sample.cfg")),
+        ([data_file("two_samples.txt")], ALL_READS, data_file("configs/auto_two_samples.cfg")),
+    ],
+)
+def test_yeat_auto_with_files(sequences, files, expected, tmp_path):
+    wd = str(tmp_path)
+    config = f"{wd}/config.cfg"
+    arglist = sequences + ["-o", config, "--files"] + files
+    run_yeat_auto(arglist)
+    compare_config_data(config, expected)
+
+
+@pytest.mark.parametrize(
+    "files,message",
+    [
+        (
+            [data_file("short_reads_1.fastq.gz")],
+            "sample short_reads: expected 2 FASTQ files for paired-end data, found 1",
+        ),
+        (["DNE", data_file("short_reads_1.fastq.gz")], "file does not exist: DNE"),
+        ([data_file("short_reads_1.fastq.gz"), "DNE"], "file does not exist: DNE"),
+    ],
+)
+def test_bad_input_files(files, message, tmp_path):
+    wd = str(tmp_path)
+    config = f"{wd}/config.cfg"
+    arglist = ["short_reads", "-o", config, "--files"] + files
+    with pytest.raises(AutoPopError, match=message):
+        run_yeat_auto(arglist)
+
+
+def test_only_files_or_seq_path_in_command(capsys, tmp_path):
+    wd = str(tmp_path)
+    config = f"{wd}/config.cfg"
+    arglist = ["short_reads", "-o", config, "--seq-path", data_file(""), "--files"] + SHORT_READS
+    with pytest.raises(SystemExit):
+        run_yeat_auto(arglist)
+    out, err = capsys.readouterr()
+    assert "error: argument --files: not allowed with argument --seq-path" in err
+
+
+def test_sample_name_within_sample(tmp_path):
+    wd = str(tmp_path)
+    config = f"{wd}/config.cfg"
+    arglist = ["short", "short_reads", "-o", config, "--seq-path", data_file("")]
+    message = "cannot correctly process a sample name that is a substring of another sample name: short vs. short_reads"
+    with pytest.raises(AutoPopError, match=message):
+        run_yeat_auto(arglist)

--- a/yeat/tests/test_yeat_auto.py
+++ b/yeat/tests/test_yeat_auto.py
@@ -9,8 +9,8 @@
 
 import pytest
 import re
-from yeat.cli.auto_pop import AutoPopError
 from yeat.cli.yeat_auto import get_parser, main
+from yeat.config.auto_pop import AutoPopError
 from yeat.tests import data_file
 
 pytestmark = pytest.mark.short
@@ -63,8 +63,9 @@ def test_bad_input_seq_path(tmp_path):
 def test_sequence_with_no_files(tmp_path):
     wd = str(tmp_path)
     config = f"{wd}/config.cfg"
-    arglist = ["SAMPLE", "-o", config, "--seq-path", data_file("")]
-    message = "sample SAMPLE: expected 2 FASTQ files for paired-end data, found 0"
+    sample_name = "SAMPLE_NAME_WITHOUT_READS"
+    arglist = [sample_name, "-o", config, "--seq-path", data_file("")]
+    message = f"sample {sample_name}: expected 2 FASTQ files for paired-end data, found 0"
     with pytest.raises(AutoPopError, match=message):
         run_yeat_auto(arglist)
 


### PR DESCRIPTION
The purpose of this PR is to automatically fill in the configuration file. When users have multiple samples, for example, 10+, it can be tedious to fill out all the paths in the sample section of the config. To ease the manual labor and to prevent potential type-os, the `yeat-auto` command was created. When using this command, users will need to supply either a 1) sample name, 2) list of sample names, or 3) a text document containing all the sample names separated by newlines. The second required input is either a list of fastq files or a directory containing the sample's fastq files (see the `--seq-path` and `--files` flags).

Auto-populating is done by taking a sample's name and looking for matching fastq files based on substrings. 

For example, the sample name is `short_reads` and the matching files are `short_read_1.fastq.gz` and `short_read_2.fastq.gz`.

Auto-populating is only available for paired-end reads. As a result, all samples are dumped into the default spades algorithm in the "assemblies" section of the config.

```
"assemblies": {
    "spades-default": {
        "algorithm": "spades",
        "extra_args": "",
        "samples": [
            "short_reads"
        ],
        "mode": "paired"
    }
}
```

Users can then run the normal YEAT command with the newly created configuration, or if there are any changes that need to be made, users can adjust the config file as needed before passing it into `yeat`.
