### PR TITLE
New short-read assembler: PenguiN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Penguin assembly support (#82)
+
+
 ## [0.6.1] 2024-07-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ $ yeat-auto short_reads --files short_reads_1.fastq.gz short_reads_2.fastq.gz
 
 | Readtype  | Algorithms |
 | ------------- | ------------- |
-| paired  | spades, megahit, unicycler |
-| single  | spades, megahit, unicycler |
+| paired  | spades, megahit, unicycler, penguin |
+| single  | spades, megahit, unicycler, penguin |
 | pacbio-raw  | flye, canu, unicycler |
 | pacbio-corr  | flye, canu, unicycler |
 | pacbio-hifi  | flye, canu, hifiasm, hifiasm_meta, unicycler, metamdbg* |

--- a/environment.yml
+++ b/environment.yml
@@ -25,5 +25,10 @@ dependencies:
     - nanofilt>=2.3
     - nanoplot>=1.20
     - hifiasm>=0.19
-    - hifiasm_meta>=hamtv0.3
+    - hifiasm_meta=hamtv0.2
     - gfatools>=0.5
+    - plass>=4.687d7
+    - gfastats>=1.3
+    - samtools>=1.21
+    - bcftools>=1.21
+    - bowtie2>=2.5

--- a/environment.yml
+++ b/environment.yml
@@ -27,8 +27,7 @@ dependencies:
     - hifiasm>=0.19
     - hifiasm_meta=hamtv0.2
     - gfatools>=0.5
-    - plass>=4.687d7
-    - gfastats>=1.3
+    - plass>=4.687d7=
     - samtools>=1.21
     - bcftools>=1.21
     - bowtie2>=2.5

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     - hifiasm>=0.19
     - hifiasm_meta=hamtv0.2
     - gfatools>=0.5
-    - plass>=4.687d7=
+    - plass>=4.687d7
     - samtools>=1.21
     - bcftools>=1.21
     - bowtie2>=2.5

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,5 @@ dependencies:
     - gfatools>=0.5
     - plass>=4.687d7
     - samtools>=1.21
-    - bcftools>=1.21
     - bowtie2>=2.5
     - pilon>=1.24

--- a/environment.yml
+++ b/environment.yml
@@ -31,3 +31,4 @@ dependencies:
     - samtools>=1.21
     - bcftools>=1.21
     - bowtie2>=2.5
+    - pilon>=1.24

--- a/yeat/config/assembly.py
+++ b/yeat/config/assembly.py
@@ -12,8 +12,8 @@ from sys import platform
 
 
 ALGORITHMS = {
-    "paired": ("spades", "megahit", "unicycler"),
-    "single": ("spades", "megahit", "unicycler"),
+    "paired": ("spades", "megahit", "unicycler", "penguin"),
+    "single": ("spades", "megahit", "unicycler", "penguin"),
     "pacbio": ("canu", "flye", "hifiasm", "hifiasm_meta", "unicycler", "metamdbg"),
     "oxford": ("canu", "flye", "unicycler"),
     "hybrid": ("unicycler"),

--- a/yeat/config/assembly.py
+++ b/yeat/config/assembly.py
@@ -93,7 +93,7 @@ class Assembly:
     def get_qa_file(self, sample):
         readtype = self.get_readtype(sample)
         algorithm_dir = f"analysis/{sample.label}/{readtype}/{self.label}/{self.algorithm}"
-        if self.bandage:
+        if self.bandage and self.algorithm != "penguin":
             return f"{algorithm_dir}/bandage/.done"
         return f"{algorithm_dir}/quast/report.html"
 

--- a/yeat/tests/test_paired.py
+++ b/yeat/tests/test_paired.py
@@ -25,7 +25,7 @@ def test_paired_end_assemblers_dry_run(tmp_path):
 
 @pytest.mark.long
 @pytest.mark.illumina
-@pytest.mark.parametrize("algorithm", ["spades", "megahit", "unicycler"])
+@pytest.mark.parametrize("algorithm", ["spades", "megahit", "unicycler", "penguin"])
 def test_paired_end_assemblers(algorithm, capsys, tmp_path):
     wd = str(tmp_path)
     config = write_config(algorithm, wd, "paired.cfg")

--- a/yeat/tests/test_single.py
+++ b/yeat/tests/test_single.py
@@ -20,7 +20,7 @@ def test_single_end_assemblers_dry_run(tmp_path):
 
 @pytest.mark.long
 @pytest.mark.illumina
-@pytest.mark.parametrize("algorithm", ["spades", "megahit", "unicycler"])
+@pytest.mark.parametrize("algorithm", ["spades", "megahit", "unicycler", "penguin"])
 def test_single_end_assemblers(algorithm, capsys, tmp_path):
     wd = str(tmp_path)
     config = write_config(algorithm, wd, "single.cfg")

--- a/yeat/workflow/Bandage
+++ b/yeat/workflow/Bandage
@@ -140,3 +140,20 @@ rule metamdbg:
         Bandage image {params.gfa} {params.outdir}/assembly_graph.jpg
         touch {output.status}
         """
+
+
+rule penguin:
+    output:
+        status="analysis/{sample}/{readtype}/{label}/penguin/bandage/.done"
+    input:
+        report="analysis/{sample}/{readtype}/{label}/penguin/quast/report.html"
+    params:
+        contigs="analysis/{sample}/{readtype}/{label}/penguin/contigs.fasta",
+        gfa="analysis/{sample}/{readtype}/{label}/penguin/contigs.gfa",
+        outdir="analysis/{sample}/{readtype}/{label}/penguin/bandage"
+    shell:
+        """
+        gfastats {params.contigs} -o gfa > {params.gfa}
+        Bandage image {params.gfa} {params.outdir}/assembly_graph.jpg
+        touch {output.status}
+        """

--- a/yeat/workflow/Bandage
+++ b/yeat/workflow/Bandage
@@ -140,20 +140,3 @@ rule metamdbg:
         Bandage image {params.gfa} {params.outdir}/assembly_graph.jpg
         touch {output.status}
         """
-
-
-rule penguin:
-    output:
-        status="analysis/{sample}/{readtype}/{label}/penguin/bandage/.done"
-    input:
-        report="analysis/{sample}/{readtype}/{label}/penguin/quast/report.html"
-    params:
-        contigs="analysis/{sample}/{readtype}/{label}/penguin/contigs.fasta",
-        gfa="analysis/{sample}/{readtype}/{label}/penguin/contigs.gfa",
-        outdir="analysis/{sample}/{readtype}/{label}/penguin/bandage"
-    shell:
-        """
-        gfastats {params.contigs} -o gfa > {params.gfa}
-        Bandage image {params.gfa} {params.outdir}/assembly_graph.jpg
-        touch {output.status}
-        """

--- a/yeat/workflow/Paired
+++ b/yeat/workflow/Paired
@@ -74,7 +74,7 @@ rule penguin:
         """
         penguin guided_nuclassemble {input.read1} {input.read2} {params.outdir}/unpolished_contigs.fasta {params.outdir} --threads {threads} {params.extra_args}
         bowtie2-build {params.outdir}/unpolished_contigs.fasta {params.outdir}/unpolished_contigs.fasta
-        bowtie2 -p {threads} -x {params.outdir}/unpolished_contigs.fasta -1 {input.read1} -2 {input.read2} 2> {params.outdir}/sample.bowtie.log | samtools view -b -@ {threads} | samtools sort -@ {threads} -o {params.outdir}/sample.sorted.bam
-        samtools index {params.outdir}/sample.sorted.bam
-        pilon --genome {params.outdir}/unpolished_contigs.fasta --bam {params.outdir}/sample.sorted.bam --output {params.outdir}/contigs
+        bowtie2 -p {threads} -x {params.outdir}/unpolished_contigs.fasta -1 {input.read1} -2 {input.read2} 2> {params.outdir}/unpolished_contigs.bowtie.log | samtools view -b -@ {threads} | samtools sort -@ {threads} -o {params.outdir}/unpolished_contigs.sorted.bam
+        samtools index {params.outdir}/unpolished_contigs.sorted.bam
+        pilon --genome {params.outdir}/unpolished_contigs.fasta --bam {params.outdir}/unpolished_contigs.sorted.bam --output {params.outdir}/contigs
         """

--- a/yeat/workflow/Paired
+++ b/yeat/workflow/Paired
@@ -58,3 +58,23 @@ rule unicycler:
         unicycler -1 {input.read1} -2 {input.read2} -t {threads} -o {params.outdir} {params.extra_args}
         ln -s assembly.fasta {output.contigs}
         """
+
+
+rule penguin:
+    output:
+        contigs="analysis/{sample}/paired/{label}/penguin/contigs.fasta"
+    input:
+        read1="seq/downsample/{sample}/paired/{sample}.R1.fq.gz",
+        read2="seq/downsample/{sample}/paired/{sample}.R2.fq.gz"
+    threads: 128
+    params:
+        outdir="analysis/{sample}/paired/{label}/penguin",
+        extra_args=lambda wildcards: config["assemblies"][wildcards.label].extra_args
+    shell:
+        """
+        penguin guided_nuclassemble {input.read1} {input.read2} {params.outdir}/unpolished_contigs.fasta {params.outdir} --threads {threads} {params.extra_args}
+        bowtie2-build {params.outdir}/unpolished_contigs.fasta {params.outdir}/unpolished_contigs.fasta
+        bowtie2 -p {threads} -x {params.outdir}/unpolished_contigs.fasta -1 {input.read1} -2 {input.read2} 2> {params.outdir}/sample.bowtie.log | samtools view -b -@ {threads} | samtools sort -@ {threads} -o {params.outdir}/sample.sorted.bam
+        samtools index {params.outdir}/sample.sorted.bam
+        pilon --genome {params.outdir}/unpolished_contigs.fasta --bam {params.outdir}/sample.sorted.bam --output {params.outdir}/contigs
+        """

--- a/yeat/workflow/Single
+++ b/yeat/workflow/Single
@@ -117,3 +117,22 @@ rule unicycler:
         unicycler -s {input.reads} -t {threads} -o {params.outdir} {params.extra_args}
         ln -s assembly.fasta {output.contigs}
         """
+
+
+rule penguin:
+    output:
+        contigs="analysis/{sample}/single/{label}/penguin/contigs.fasta"
+    input:
+        reads="seq/downsample/{sample}/single/combined-reads.fq.gz"
+    threads: 128
+    params:
+        outdir="analysis/{sample}/single/{label}/penguin",
+        extra_args=lambda wildcards: config["assemblies"][wildcards.label].extra_args
+    shell:
+        """
+        penguin guided_nuclassemble {input.reads} {params.outdir}/unpolished_contigs.fasta {params.outdir} --threads {threads} {params.extra_args}
+        bowtie2-build {params.outdir}/unpolished_contigs.fasta {params.outdir}/unpolished_contigs.fasta
+        bowtie2 -p {threads} -x {params.outdir}/unpolished_contigs.fasta -U {input.reads} 2> {params.outdir}/sample.bowtie.log | samtools view -b -@ {threads} | samtools sort -@ {threads} -o {params.outdir}/sample.sorted.bam
+        samtools index {params.outdir}/sample.sorted.bam
+        pilon --genome {params.outdir}/unpolished_contigs.fasta --bam {params.outdir}/sample.sorted.bam --output {params.outdir}/contigs
+        """

--- a/yeat/workflow/Single
+++ b/yeat/workflow/Single
@@ -132,7 +132,7 @@ rule penguin:
         """
         penguin guided_nuclassemble {input.reads} {params.outdir}/unpolished_contigs.fasta {params.outdir} --threads {threads} {params.extra_args}
         bowtie2-build {params.outdir}/unpolished_contigs.fasta {params.outdir}/unpolished_contigs.fasta
-        bowtie2 -p {threads} -x {params.outdir}/unpolished_contigs.fasta -U {input.reads} 2> {params.outdir}/sample.bowtie.log | samtools view -b -@ {threads} | samtools sort -@ {threads} -o {params.outdir}/sample.sorted.bam
-        samtools index {params.outdir}/sample.sorted.bam
-        pilon --genome {params.outdir}/unpolished_contigs.fasta --bam {params.outdir}/sample.sorted.bam --output {params.outdir}/contigs
+        bowtie2 -p {threads} -x {params.outdir}/unpolished_contigs.fasta -U {input.reads} 2> {params.outdir}/unpolished_contigs.bowtie.log | samtools view -b -@ {threads} | samtools sort -@ {threads} -o {params.outdir}/unpolished_contigs.sorted.bam
+        samtools index {params.outdir}/unpolished_contigs.sorted.bam
+        pilon --genome {params.outdir}/unpolished_contigs.fasta --bam {params.outdir}/unpolished_contigs.sorted.bam --output {params.outdir}/contigs
         """


### PR DESCRIPTION
PenguiN (Protein-guided Nucleotide Assembler) is a relatively new assembler that takes a slightly different approach to assembly. It uses the coding sequences of reads and translates them into protein sequences to guide the assembly process. According to the creator of PenguiN, "The main purpose of PenguiN is the assembly of complex metagenomic and metatranscriptomic datasets."

In our own tests, we have found that the final contigs may introduce unintended SNPs, depending on the number of iterations provided to the assembler. To address this issue, we clean up the contigs using `pilon` to polish the reads. This tool has shown a significant improvement in base accuracy.

One of the benefits we have found when using PenguiN is its ability to provide multiple full-length contigs. While this could be seen as a downside, as opposed to having a single consensus sequence, it gives users the option to choose the best contig avaliable.

Notes:
- One useful `extra_args` entry that users can input into YEAT's config is `--num-iterations`. (The test results mentioned above used 5 (default), 10, and 15.)
- No Bandage files are created for PenguiN assemblies because no `.gfa` or similar files are created by the assembler.