### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,6 +28,7 @@ dependencies:
     - hifiasm_meta=hamtv0.2
     - gfatools>=0.5
     - plass>=4.687d7
-    - samtools>=1.21
+    - samtools=1.20
     - bowtie2>=2.5
     - pilon>=1.24
+    - pulp=2.7.0


### PR DESCRIPTION
- samtools 1.21 was leading to a dependency conflict hell, so pinned to 1.20 (which is what is on our current install)
- pulp 2.8.0 was leading to an Attr. Err.: no attr. 'list_solvers', so added and pinned to 2.7.0 (which is what is on our current install)

pulp wasn't in the yaml at all, so i'm sure that is fine. But of course if yeat was deliberately updated samtools 1.21 for a reason that 1.20 won't work, then more needs to be figured out to resolve the dependencies (though i didn't see any issues with yeat or just-yeat-it test runs)