### PR TITLE
touching some things up

### DIFF
--- a/yeat/cli/aux.py
+++ b/yeat/cli/aux.py
@@ -8,6 +8,7 @@
 # -------------------------------------------------------------------------------------------------
 
 from argparse import ArgumentTypeError
+from pathlib import Path
 
 
 def check_positive(value):
@@ -18,3 +19,7 @@ def check_positive(value):
     except ValueError:
         raise ArgumentTypeError(f"{value} is not an integer")
     return value
+
+
+def get_slurm_logs_dir(wd):
+    return Path(wd).resolve() / "slurm-logs/"

--- a/yeat/cli/cli.py
+++ b/yeat/cli/cli.py
@@ -162,7 +162,7 @@ def grid_configuration(parser):
         "--grid-args",
         default=None,
         help="""additional arguments passed to the scheduler to configure grid execution; " -V " 
-        is passed by default, or " -V -pe threads <T> " ("sbatch -c <T> " if using SLURM) 
+        is passed by default, or " -V -pe threads <T> " ("sbatch -o ${log_output} -e ${log_output} -c <T> " if using SLURM) 
         if --threads is set; this can be used for example to configure grid queue or priority, 
         e.g., " -q largemem -p -1000 " ("sbatch -p largemem --priority -1000 "); 
         note that when overriding the defaults, the user must explicitly add the " -V " ("sbatch") and threads 

--- a/yeat/cli/just_yeat_it.py
+++ b/yeat/cli/just_yeat_it.py
@@ -19,7 +19,8 @@ def main(args=None):
         args = get_parser().parse_args()  # pragma: no cover
     create_config(args)
     add_config(args)
-    setattr(args, "grid", False)
+    if not args.grid:
+        setattr(args, "grid", False)
     workflow.run_workflow(args)
 
 
@@ -27,6 +28,7 @@ def get_parser(exit_on_error=True):
     parser = ArgumentParser(exit_on_error=exit_on_error)
     parser._optionals.title = "options"
     cli.workflow_configuration(parser)
+    cli.grid_configuration(parser)
     illumina.fastp_configuration(parser)
     illumina.downsample_configuration(parser, just_yeat_it=True)
     sample_configuration(parser)

--- a/yeat/workflow/Paired
+++ b/yeat/workflow/Paired
@@ -17,9 +17,11 @@ rule spades:
     params:
         outdir="analysis/{sample}/paired/{label}/spades",
         extra_args=lambda wildcards: config["assemblies"][wildcards.label].extra_args
+    log:
+        "analysis/{sample}/paired/{label}/spades/spades-stdout-err.log"
     shell:
         """
-        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o {params.outdir} {params.extra_args}
+        spades.py -1 {input.read1} -2 {input.read2} -t {threads} -o {params.outdir} {params.extra_args} > {log} 2>&1
         """
 
 
@@ -34,9 +36,11 @@ rule megahit:
         temp_dir="analysis/{sample}/paired/{label}/megahit-temp",
         actual_dir="analysis/{sample}/paired/{label}/megahit",
         extra_args=lambda wildcards: config["assemblies"][wildcards.label].extra_args
+    log:
+        "analysis/{sample}/paired/{label}/megahit/megahit.log"
     shell:
         """
-        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o {params.temp_dir} {params.extra_args}
+        megahit -1 {input.read1} -2 {input.read2} -t {threads} -o {params.temp_dir} {params.extra_args} > {log} 2>&1
         mv {params.temp_dir}/* {params.actual_dir}
         rm -r {params.temp_dir}
         ln -s final.contigs.fa {output.contigs}

--- a/yeat/workflow/Shared
+++ b/yeat/workflow/Shared
@@ -35,9 +35,11 @@ rule fastqc_paired:
     threads: 128
     params:
         outdir="seq/fastqc/{sample}/paired"
+    log:
+        "seq/fastqc/{sample}/paired/fastqc.log"
     shell:
         """
-        fastqc {input.read1} {input.read2} -t {threads} -o {params.outdir}
+        fastqc {input.read1} {input.read2} -t {threads} -o {params.outdir} > {log} 2>&1
         """
 
 
@@ -131,9 +133,11 @@ rule fastqc_single:
     threads: 128
     params:
         outdir="seq/fastqc/{sample}/{readtype}"
+    log:
+        "seq/fastqc/{sample}/{readtype}/fastqc.log"
     shell:
         """
-        fastqc {input.reads} -t {threads} -o {params.outdir}
+        fastqc {input.reads} -t {threads} -o {params.outdir} > {log} 2>&1
         """
 
 
@@ -144,7 +148,9 @@ rule quast:
         contigs="analysis/{sample}/{readtype}/{label}/{assembler}/contigs.fasta"
     params:
         outdir="analysis/{sample}/{readtype}/{label}/{assembler}/quast"
+    log:
+        "analysis/{sample}/{readtype}/{label}/{assembler}/quast/quast.log"
     shell:
         """
-        quast.py {input.contigs} -o {params.outdir}
+        quast.py {input.contigs} -o {params.outdir} > {log} 2>&1
         """

--- a/yeat/workflow/aux.py
+++ b/yeat/workflow/aux.py
@@ -37,14 +37,14 @@ def get_canu_readtype_flag(readtype):
 
 def combine(reads, direction, outdir):
     for i, inread in enumerate(reads):
-        outread = f"{outdir}/{direction}_reads{i}.fq"
-        if inread.endswith(".gz"):
-            subprocess.run(f"gunzip -c {inread} > {outread}", shell=True)
+        outread = f"{outdir}/{direction}_reads{i}.fq.gz"
+        if not inread.endswith(".gz"):
+            subprocess.run(f"gzip {inread} > {outread}", shell=True)
         else:
             shutil.copyfile(inread, outread)
     commands = (
-        f"cat {outdir}/{direction}_reads*.fq > {outdir}/{direction}_combined-reads.fq;"
-        f"gzip {outdir}/{direction}_combined-reads.fq"
+        f"cat {outdir}/{direction}_reads*.fq.gz > {outdir}/{direction}_combined-reads.fq.gz;"
+        f"rm {outdir}/{direction}_reads*.fq.gz"
     )
     subprocess.run(commands, shell=True)
 


### PR DESCRIPTION
- reduced some redundancy and sped things up by remoing unneeded gunzip/gzip of starting read files
- added log files to capture large stdout/err from the workflow for fastqc, quast, spades, and megahit
- output slurm logs are captured in a dedicated directory instead of swamping the primary output dir
- connected slurm capability to just-yeat-it